### PR TITLE
Made navbar such that it will be able to contain more tabs

### DIFF
--- a/frontend/src/components/navbar/navbar.css
+++ b/frontend/src/components/navbar/navbar.css
@@ -17,10 +17,7 @@
 }
 
 .nav-menu {
-  display: grid;
-  grid-template-columns: repeat(7, auto);
-  grid-gap: 10px;
-  list-style: none;
+  display: flex;
   text-align: center;
   width: 70vw;
   justify-content: start;
@@ -31,6 +28,7 @@
 
 .nav-item {
   display: flex;
+  margin: 5px;
   align-items: center;
   height: 60px;
 }


### PR DESCRIPTION
This commit is followed by following comment:
https://github.com/HITK-TECH-Community/Community-Website/issues/164#issuecomment-753477090

## Issue that this pull request solves
Issue mentioned in [this comment](https://github.com/HITK-TECH-Community/Community-Website/issues/164#issuecomment-753473558)

## Proposed changes

### Brief description of what is fixed or changed
Navbar had a CSS property `display` of value `grid` which resulted in navbar items getting distorted when more items were added.
I changed that to `display` as `flex` so now it can utilize full area available.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

![image](https://user-images.githubusercontent.com/70993547/103458197-ba550a80-4d2b-11eb-87ad-70a568a3231c.png)
