### PR TITLE
Made the title and text centre aligned in mobile view in home page

### DIFF
--- a/frontend/src/components/home/overview/overview.css
+++ b/frontend/src/components/home/overview/overview.css
@@ -70,11 +70,21 @@
 
   .overview p {
     font-size: 1.3rem;
+    text-align: center;
   }
 
   .overview img {
     order: -1;
     min-width: auto;
     width: 180px;
+  }
+
+  .overview h1 {
+    text-align: center;
+  }
+
+  .overview .dash {
+    margin: auto;
+    margin-bottom: 10px;
   }
 }


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #249 

## Proposed changes

### Brief description of what is fixed or changed
Made the title and text center aligned in order to attain consistency in design in mobile view. 


## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
![github-pull](https://user-images.githubusercontent.com/58511560/104220651-d2cccf80-5465-11eb-8f46-e22da02a0663.PNG)



## Other information

Any other information that is important to this pull request
