### PR TITLE
changed the size of footer icons

### DIFF
--- a/frontend/src/components/footer/footer.css
+++ b/frontend/src/components/footer/footer.css
@@ -183,8 +183,8 @@
 }
 
 .col .social li a .outer {
-  height: calc(50px + 2 * var(--w));
-  width: calc(50px + 2 * var(--w));
+  height: calc(40px + 2 * var(--w));
+  width: calc(40px + 2 * var(--w));
   overflow: hidden;
   border-radius: 10px;
   position: relative;
@@ -192,8 +192,8 @@
 
 .col .social li a .inner {
   z-index: 1;
-  width: calc(50px + var(--w));
-  height: calc(50px + var(--w));
+  width: calc(40px + var(--w));
+  height: calc(40px + var(--w));
   border-radius: 10px;
   position: absolute;
   background: #121f3a;

--- a/frontend/src/components/footer/footer.js
+++ b/frontend/src/components/footer/footer.js
@@ -97,7 +97,7 @@ const Footer = () => {
                       <span></span>
                       <span></span>
                       <div className="inner">
-                        <i className="fab fa-linkedin  fa-2x"></i>
+                        <i className="fab fa-linkedin  fa-lg"></i>
                       </div>
                     </div>
                   </a>
@@ -114,7 +114,7 @@ const Footer = () => {
                       <span></span>
                       <span></span>
                       <div className="inner">
-                        <i className="fab fa-slack  fa-2x"></i>
+                        <i className="fab fa-slack  fa-lg"></i>
                       </div>
                     </div>
                   </a>
@@ -131,7 +131,7 @@ const Footer = () => {
                       <span></span>
                       <span></span>
                       <div className="inner">
-                        <i className="fas fa-envelope  fa-2x"></i>
+                        <i className="fas fa-envelope  fa-lg"></i>
                       </div>
                     </div>
                   </a>
@@ -148,7 +148,7 @@ const Footer = () => {
                       <span></span>
                       <span></span>
                       <div className="inner">
-                        <i className="fab fa-github  fa-2x"></i>
+                        <i className="fab fa-github  fa-lg"></i>
                       </div>
                     </div>
                   </a>


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #339 (DWoC)

## Proposed changes
Enhancement in Footer Icons

### Brief description of what is fixed or changed
Made the size of footer icons a bit smaller so that it looks consistent with the size of other contents in the footer

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
![icons_1](https://user-images.githubusercontent.com/58511560/106785786-cd813000-6673-11eb-8129-9c649f60036a.PNG)

## Other information

Any other information that is important to this pull request

