### PR TITLE
Collapsible menu for small screen added in admin page

### DIFF
--- a/frontend/src/pages/Admin/Admin.jsx
+++ b/frontend/src/pages/Admin/Admin.jsx
@@ -22,7 +22,11 @@ import { useDispatch } from "react-redux";
 
 export const Admin = () => {
   const [tab, setTab] = useState(1);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const toggleNav = () => setIsMenuOpen(!isMenuOpen);
+  const closeMobileMenu = () => setIsMenuOpen(false);
   const dispatch = useDispatch();
+
   return (
     <div style={{ minHeight: "100vh" }}>
       <div className={style["dashing"]}>
@@ -35,98 +39,132 @@ export const Admin = () => {
             />
             <h1 className={style["h1"]}>Welcome Admin!</h1>
           </div>
-          <div
+          <ul
             className={
-              tab === 1 ? style["features-icons"] : style["features-icons1"]
+              isMenuOpen ? `${style["menu"]} ${style["active"]}` : style["menu"]
             }
-            onClick={() => setTab(1)}
           >
-            <DashboardIcon style={{ fontSize: 23.32 }} />
-            <div className={style["span"]}>Dashboard</div>
-          </div>
-          <div
-            className={
-              tab === 2 ? style["features-icons"] : style["features-icons1"]
-            }
-            onClick={() => setTab(2)}
-          >
-            <i className="fas fa-bullhorn fa-fw fa-lg" aria-hidden="true"></i>
-            <div className={style["span"]}>Broadcasts</div>
-          </div>
-          <div
-            className={
-              tab === 3 ? style["features-icons"] : style["features-icons1"]
-            }
-            onClick={() => setTab(3)}
-          >
+            <li onClick={closeMobileMenu}>
+              <div
+                className={
+                  tab === 1 ? style["features-icons"] : style["features-icons1"]
+                }
+                onClick={() => setTab(1)}
+              >
+                <DashboardIcon style={{ fontSize: 23.32 }} />
+                <div className={style["span"]}>Dashboard</div>
+              </div>
+            </li>
+            <li onClick={closeMobileMenu}>
+              <div
+                className={
+                  tab === 2 ? style["features-icons"] : style["features-icons1"]
+                }
+                onClick={() => setTab(2)}
+              >
+                <i
+                  className="fas fa-bullhorn fa-fw fa-lg"
+                  aria-hidden="true"
+                ></i>
+                <div className={style["span"]}>Broadcasts</div>
+              </div>
+            </li>
+            <li onClick={closeMobileMenu}>
+              <div
+                className={
+                  tab === 3 ? style["features-icons"] : style["features-icons1"]
+                }
+                onClick={() => setTab(3)}
+              >
+                <i
+                  className="fas fa-user-circle fa-fw fa-lg"
+                  aria-hidden="true"
+                ></i>
+                <div className={style["span"]}>Contact Us</div>
+              </div>
+            </li>
+            <li onClick={closeMobileMenu}>
+              <div
+                className={
+                  tab === 4 ? style["features-icons"] : style["features-icons1"]
+                }
+                onClick={() => setTab(4)}
+              >
+                <i className="fas fa-users fa-fw fa-lg" aria-hidden="true"></i>
+                <div className={style["span"]}>About Us</div>
+              </div>
+            </li>
+            <li onClick={closeMobileMenu}>
+              <div
+                className={
+                  tab === 11
+                    ? style["features-icons"]
+                    : style["features-icons1"]
+                }
+                onClick={() => setTab(11)}
+              >
+                <i
+                  className="fas fa-handshake fa-fw fa-lg"
+                  aria-hidden="true"
+                ></i>
+                <div className={style["span"]}>Join Us</div>
+              </div>
+            </li>
+            <li onClick={closeMobileMenu}>
+              <div
+                className={
+                  tab === 12
+                    ? style["features-icons"]
+                    : style["features-icons1"]
+                }
+                onClick={() => setTab(12)}
+              >
+                <i className="fas fa-book fa-fw fa-lg" aria-hidden="true"></i>
+                <div className={style["span"]}>Resources</div>
+              </div>
+            </li>
+            <li onClick={closeMobileMenu}>
+              <div
+                className={
+                  tab === 5 ? style["features-icons"] : style["features-icons1"]
+                }
+                onClick={() => setTab(5)}
+              >
+                <i
+                  className="fas fa-question fa-fw fa-lg"
+                  aria-hidden="true"
+                ></i>
+                <div className={style["span"]}>FAQs</div>
+              </div>
+            </li>
+            <li onClick={closeMobileMenu}>
+              <div
+                className={
+                  tab === 6 ? style["features-icons"] : style["features-icons1"]
+                }
+                onClick={() => setTab(6)}
+              >
+                <i className="fas fa-cog fa-fw fa-lg" aria-hidden="true"></i>
+                <div className={style["span"]}>Settings</div>
+              </div>
+            </li>
+            <li onClick={closeMobileMenu}>
+              <div
+                className={style["features-icons1"]}
+                onClick={() => logout(dispatch)}
+              >
+                <i
+                  className="fas fa-sign-out-alt fa-fw fa-lg"
+                  aria-hidden="true"
+                ></i>
+                <div className={style["span"]}>Logout</div>
+              </div>
+            </li>
+          </ul>
+          <div className={style["menu-icon"]} onClick={toggleNav}>
             <i
-              className="fas fa-user-circle fa-fw fa-lg"
-              aria-hidden="true"
+              className={isMenuOpen ? "fas fa-angle-up" : "fas fa-angle-down"}
             ></i>
-            <div className={style["span"]}>Contact Us</div>
-          </div>
-          <div
-            className={
-              tab === 4 ? style["features-icons"] : style["features-icons1"]
-            }
-            onClick={() => setTab(4)}
-          >
-            <i className="fas fa-users fa-fw fa-lg" aria-hidden="true"></i>
-            <div className={style["span"]}>About Us</div>
-          </div>
-
-          <div
-            className={
-              tab === 11 ? style["features-icons"] : style["features-icons1"]
-            }
-            onClick={() => setTab(11)}
-          >
-            <i
-              className="fas fa-handshake fa-fw fa-lg"
-              aria-hidden="true"
-            ></i>
-            <div className={style["span"]}>Join Us</div>
-          </div>
-
-          <div
-            className={
-              tab === 12 ? style["features-icons"] : style["features-icons1"]
-            }
-            onClick={() => setTab(12)}
-          >
-            <i
-              className="fas fa-book fa-fw fa-lg"
-              aria-hidden="true"
-            ></i>
-            <div className={style["span"]}>Resources</div>
-          </div>
-          <div
-            className={
-              tab === 5 ? style["features-icons"] : style["features-icons1"]
-            }
-            onClick={() => setTab(5)}
-          >
-            <i className="fas fa-question fa-fw fa-lg" aria-hidden="true"></i>
-            <div className={style["span"]}>FAQs</div>
-          </div>
-          <div
-            className={
-              tab === 6 ? style["features-icons"] : style["features-icons1"]
-            }
-            onClick={() => setTab(6)}
-          >
-            <i className="fas fa-cog fa-fw fa-lg" aria-hidden="true"></i>
-            <div className={style["span"]}>Settings</div>
-          </div>
-          <div
-            className={style["features-icons1"]}
-            onClick={() => logout(dispatch)}
-          >
-            <i
-              className="fas fa-sign-out-alt fa-fw fa-lg"
-              aria-hidden="true"
-            ></i>
-            <div className={style["span"]}>Logout</div>
           </div>
         </div>
         <div className={style["right"]}>

--- a/frontend/src/pages/Admin/admin.module.scss
+++ b/frontend/src/pages/Admin/admin.module.scss
@@ -86,6 +86,14 @@
   align-items: center;
 }
 
+.menu-icon {
+  display: none;
+}
+
+.left > ul {
+  padding-left: 0;
+}
+
 @media (max-width: 600px) {
   .dashing {
     flex-direction: column;
@@ -99,5 +107,52 @@
   .right {
     width: 100%;
     margin: 1em auto;
+  }
+
+  .welcome-section {
+    flex-direction: row;
+    justify-content: flex-start;
+    min-height: 0;
+    margin: 0;
+  }
+
+  .welcome-section > img {
+    max-width: 40px;
+    margin: 0;
+  }
+
+  .welcome-section > h1 {
+    margin-top: 0;
+    margin-left: 10px;
+  }
+
+  .menu-icon {
+    display: block;
+    position: absolute;
+    right: 3.2rem;
+    padding: 22px;
+    font-size: 1.8rem;
+    cursor: pointer;
+    color: #fff;
+  }
+
+  .menu {
+    max-height: 0;
+    overflow: hidden;
+    -webkit-transition: max-height 0.5s;
+    -moz-transition: max-height 0.5s;
+    transition: max-height 0.5s;
+  }
+
+  .menu.active {
+    max-height: 100vh;
+  }
+
+  .left {
+    min-height: 0;
+  }
+
+  .left > ul > li:first-child {
+    margin-top: 25px;
   }
 }


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #553 

## Proposed changes

### Brief description of what is fixed or changed

Left menu of admin page has been modified for small screen to be a dropping menu.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

![rec1](https://user-images.githubusercontent.com/44370673/112279337-d4a6e080-8ca9-11eb-9c69-11f2e545fbde.gif)


## Other information

Any other information that is important to this pull request
