### PR TITLE
Send Contact Us Form Response to Admins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 backend/node_modules/
 .vscode
 backend/package-lock.json
+backend/.env

--- a/backend/app/models/ContactUs.js
+++ b/backend/app/models/ContactUs.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const contactUsUserSchema = new Schema(
+  {
+    name: {
+      type: String,
+      min: [3, 'Name length must be at least 3 characters long'],
+      required: true,
+      trim: true,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    subject: {
+      type: String,
+      required: true,
+      min: [5, 'Subject length must be at least 5 characters long'],
+      trim: true,
+    },
+    message: {
+      type: String,
+      required: true,
+      min: [8, 'Message length must be at least 8 characters long'],
+      trim: true,
+    },
+  },
+  { timestamps: { createdAt: 'createdAt', updatedAt: 'updatedAt' } }
+);
+
+module.exports = mongoose.model('ContactUsUsers', contactUsUserSchema);

--- a/backend/app/routes/contactus/@validationSchema/index.js
+++ b/backend/app/routes/contactus/@validationSchema/index.js
@@ -1,0 +1,14 @@
+const Joi = require('joi');
+
+const postResponseSchema = Joi.object({
+  name: Joi.string()
+    .optional()
+    .pattern(/[a-zA-z]+$/, 'aplha'),
+  email: Joi.string().min(3).required().email(),
+  subject: Joi.string().min(5),
+  message: Joi.string().min(8),
+});
+
+module.exports = {
+  postResponseSchema,
+};

--- a/backend/app/routes/contactus/getAdmins.js
+++ b/backend/app/routes/contactus/getAdmins.js
@@ -1,0 +1,17 @@
+const to = require('await-to-js').default;
+const Admin = require('../../models/Admin');
+const { ErrorHandler } = require('../../../helpers/error');
+const constants = require('../../../constants');
+
+module.exports = async (req, res, next) => {
+  const [err, response] = await to(Admin.find().select('email -_id'));
+  if (err) {
+    const error = new ErrorHandler(constants.ERRORS.DATABASE, {
+      statusCode: '500',
+      message: 'The server encountered an unexpected condition which prevented it from fulfilling the request.',
+      errorStack: err,
+    });
+    return next(error);
+  }
+  return response;
+};

--- a/backend/app/routes/contactus/index.js
+++ b/backend/app/routes/contactus/index.js
@@ -1,7 +1,9 @@
 const router = require('express').Router({ mergeParams: true });
+const validationMiddleware = require('../../../helpers/middlewares/validation');
 
 const postResponse = require('./postResponse');
+const { postResponseSchema } = require('./@validationSchema');
 
-router.post('/', postResponse);
+router.post('/', validationMiddleware(postResponseSchema), postResponse);
 
 module.exports = router;

--- a/backend/app/routes/contactus/index.js
+++ b/backend/app/routes/contactus/index.js
@@ -1,0 +1,7 @@
+const router = require('express').Router({ mergeParams: true });
+
+const postResponse = require('./postResponse');
+
+router.post('/', postResponse);
+
+module.exports = router;

--- a/backend/app/routes/contactus/postResponse.js
+++ b/backend/app/routes/contactus/postResponse.js
@@ -2,14 +2,15 @@ const to = require('await-to-js').default;
 const ContactUs = require('../../models/ContactUs');
 const { ErrorHandler } = require('../../../helpers/error');
 const constants = require('../../../constants');
-// TODO:const { sendEmail } = require('../../../helpers/emailService');
+const getAdmins = require('./getAdmins');
+const sendEmails = require('./sendEmails');
 
 module.exports = async (req, res, next) => {
   const contactusData = {
     ...req.body,
   };
 
-  const [err, contactUsResponse] = await to(ContactUs.create(contactusData));
+  const [err, response] = await to(ContactUs.create(contactusData));
   if (err) {
     const error = new ErrorHandler(constants.ERRORS.DATABASE, {
       statusCode: 500,
@@ -20,16 +21,13 @@ module.exports = async (req, res, next) => {
     return next(error);
   }
 
-  // TODO:SEND EMAIL TO ALL ADMINS
+  const getAdminEmails = await getAdmins(req, res, next);
 
-  // eslint-disable-next-line no-underscore-dangle
-  const responseDoc = { ...contactUsResponse._doc };
+  await sendEmails(req, res, getAdminEmails, next);
+
   res.status(200).send({
-    status: 'Success, Your response has been submitted',
-    name: responseDoc.name,
-    email: responseDoc.email,
-    subject: responseDoc.subject,
-    message: responseDoc.message,
+    message: 'Your request has been submitted!',
+    your_response: response,
   });
   return next();
 };

--- a/backend/app/routes/contactus/postResponse.js
+++ b/backend/app/routes/contactus/postResponse.js
@@ -1,0 +1,35 @@
+const to = require('await-to-js').default;
+const ContactUs = require('../../models/ContactUs');
+const { ErrorHandler } = require('../../../helpers/error');
+const constants = require('../../../constants');
+// TODO:const { sendEmail } = require('../../../helpers/emailService');
+
+module.exports = async (req, res, next) => {
+  const contactusData = {
+    ...req.body,
+  };
+
+  const [err, contactUsResponse] = await to(ContactUs.create(contactusData));
+  if (err) {
+    const error = new ErrorHandler(constants.ERRORS.DATABASE, {
+      statusCode: 500,
+      message: 'Mongo Error: Insertion Failed',
+      errStack: err,
+      user: req.body.email,
+    });
+    return next(error);
+  }
+
+  // TODO:SEND EMAIL TO ALL ADMINS
+
+  // eslint-disable-next-line no-underscore-dangle
+  const responseDoc = { ...contactUsResponse._doc };
+  res.status(200).send({
+    status: 'Success, Your response has been submitted',
+    name: responseDoc.name,
+    email: responseDoc.email,
+    subject: responseDoc.subject,
+    message: responseDoc.message,
+  });
+  return next();
+};

--- a/backend/app/routes/contactus/sendEmails.js
+++ b/backend/app/routes/contactus/sendEmails.js
@@ -1,0 +1,25 @@
+const { ErrorHandler } = require('../../../helpers/error');
+const { sendEmail } = require('../../../helpers/emailService');
+const constants = require('../../../constants');
+
+module.exports = async (req, res, emails, next) => {
+  const data = { ...req.body };
+
+  try {
+    emails.map(async (item) => {
+      const response = await sendEmail(item.email, data, 'USER-CONTACT-US-FORM');
+      return response;
+    });
+  } catch (err) {
+    if (err) {
+      const error = new ErrorHandler(constants.ERRORS.UNEXPECTED, {
+        statusCode: '500',
+        message: 'The server encountered an unexpected condition which prevented it from fulfilling the request.',
+        errorStack: err,
+      });
+      return next(error);
+    }
+  }
+
+  return 'Responses Sent';
+};

--- a/backend/app/routes/index.js
+++ b/backend/app/routes/index.js
@@ -3,10 +3,12 @@ const admin = require('./admin');
 const auth = require('./auth');
 const { emailTest } = require('./testRoutes/emailTest');
 const tinyURL = require('./tinyURL');
+const contactus = require('./contactus');
 
 router.use('/admin', admin);
 router.use('/auth', auth);
 router.post('/emailTest', emailTest);
 router.use('/', tinyURL);
+router.use('/contactus', contactus);
 
 module.exports = router;

--- a/backend/helpers/emailService.js
+++ b/backend/helpers/emailService.js
@@ -20,7 +20,8 @@ const transporter = nodemailer.createTransport({
 
 module.exports.sendEmail = async (email, data, type) => {
   const template = getMailTemplate(type);
-  const { subject } = template;
+  let { subject } = template;
+  subject = ejs.render(subject, data);
   let { text } = template;
   text = ejs.render(text, data);
   const mailOptions = {

--- a/backend/utility/emailTemplates.js
+++ b/backend/utility/emailTemplates.js
@@ -9,6 +9,11 @@ module.exports.getMailTemplate = (type) => {
       text:
         'Hi <%= name %> \n We would love for you to join us at HITK Tech Community as an admin.\n\tHITK Tech Community is a platform built by the students and for the students with the main intent of increasing awareness towards plethora of opportunities and internships in tech all around/over the year. This will not only give practical work experience/exposure to students, but will also help everyone to know and grab their required opportunities in time!\nClick on <%= link %> for further action',
     },
+    'USER-CONTACT-US-FORM': {
+      // html:"",
+      subject: '[USER-REQUEST] <%= subject %>',
+      text: 'Dear Sir/Madam, \n\n\t<%= message %>\n\nThanks,\n<%= name %>,\n<%= email %>',
+    },
   };
   return templates[type];
 };


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #499 

## Proposed changes

### Brief description of what is fixed or changed

Contact Us Model to store the response of the users is created and as soon as the user sends the response, an email is sent
to the admins following a template mentioned in utility folder.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
------------

## Other information

Any other information that is important to this pull request
