### PR TITLE
Added delete functionality in manage broadcast page with Admin access only

### DIFF
--- a/frontend/src/pages/Broadcast/Component/AllBroadcasts/AllBroadcasts.jsx
+++ b/frontend/src/pages/Broadcast/Component/AllBroadcasts/AllBroadcasts.jsx
@@ -14,7 +14,6 @@ export function AllBroadcasts(props) {
   const [array, setArray] = useState([]);
   const [index, setIndex] = useState(0);
   const [visible, setVisible] = useState(false);
-  const [isAdmin] = useState(true);
   const [tags, setTags] = useState("");
   const [month, setMonth] = useState("");
   const [year, setYear] = useState("");
@@ -215,9 +214,8 @@ export function AllBroadcasts(props) {
               theme={dark}
               project={element}
               key={`card-${i}`}
-              id={`card-${i}`}
+              id={element._id}
               handler={() => handler(i)}
-              admin={isAdmin}
             />
           );
         })}

--- a/frontend/src/pages/Broadcast/Component/AllBroadcasts/Card/Card.jsx
+++ b/frontend/src/pages/Broadcast/Component/AllBroadcasts/Card/Card.jsx
@@ -4,22 +4,22 @@ import { Modals } from "../../Carousel/Modal/index.js";
 import { Delete, Edit } from "@material-ui/icons";
 import { IconButton } from "@material-ui/core";
 import { useSelector } from "react-redux";
-
+import { END_POINT } from "../../../../../config/api";
+import { SimpleToast } from "../../../../../components/util/Toast";
 import style from "./card.module.scss";
 
-function deleteCard(id) {
-  const cardElement = document.getElementById(id);
-  cardElement.classList.add("gonnaRemove");
-  setTimeout(() => cardElement.remove(), 1000);
-}
 export function Card(props) {
   let dark = props.theme;
   const [flipped, setFlipped] = useState(false);
+  const [openDeleteSuccess, setOpenDeleteSuccess] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState({});
+
   const handleClick = () => {
     setFlipped(!flipped);
   };
-  const [open, setOpen] = useState(false);
-  const [data, setData] = useState({});
+
   const handleOpen = (s, h, i) => {
     setOpen(true);
     setData({ head: h, desc: s, img: i });
@@ -29,6 +29,34 @@ export function Card(props) {
     setOpen(false);
     setData({});
   };
+
+  const handleCloseDeleteToast = (event, reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setOpenDeleteSuccess(false);
+  };
+
+  function deleteCard(id) {
+    var api = `${END_POINT}/broadcast/${id}`;
+    const token = localStorage.getItem("token");
+    return fetch(api, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    })
+      .then(() => {
+        setSuccessMessage("Broadcast deleted successfully");
+        setOpenDeleteSuccess(true);
+        setTimeout(() => {
+          window.location.reload();
+        }, 3000);
+      })
+      .catch((err) => console.log(err));
+  }
+
   const isSuperAdmin = useSelector((state) => state.isSuperAdmin);
   const date = new Date(props.project.createdAt.slice(0, 10));
   var months = [
@@ -123,6 +151,14 @@ export function Card(props) {
           </div>
         </div>
       </ReactCardFlip>
+      {openDeleteSuccess && (
+        <SimpleToast
+          open={openDeleteSuccess}
+          message={successMessage}
+          handleCloseToast={handleCloseDeleteToast}
+          severity="success"
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #682 

### Brief description of what is fixed or changed
In the 'all-broadcasts' page itself, if logged in as admin provided access to delete broadcasts by calling suitable api with the id being passed as a param.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

https://user-images.githubusercontent.com/71957423/154796928-be0e809f-4947-4ca0-9ed7-be274cfa85d0.mp4

