### PR TITLE
Allow admins to get join us requests

### DIFF
--- a/backend/app/routes/index.js
+++ b/backend/app/routes/index.js
@@ -7,7 +7,7 @@ const broadcast = require('./broadcast');
 const faq = require('./faq/post');
 const getFaq = require('./faq/getFaq');
 const deleteFaq = require('./faq/deleteFaq');
-const joinUs = require('./joinUs/post');
+const joinUs = require('./joinUs/');
 const contactUs = require('./contactUs/post');
 const question = require('./Q&A/question');
 const answer = require('./Q&A/answers');
@@ -22,7 +22,7 @@ router.use('/contactus', contactUs);
 router.use('/broadcast', broadcast);
 router.use('/question', question);
 router.use('/answers', answer);
-router.use('/', tinyURL);
-router.use('/joinUs', joinUs);
+router.use('/joinUs', joinUs)
 router.use('/teamMember', teamMember);
+router.use('/', tinyURL);
 module.exports = router;

--- a/backend/app/routes/joinUs/get.js
+++ b/backend/app/routes/joinUs/get.js
@@ -1,0 +1,11 @@
+const joinUsModel = require('../../models/joinUs');
+
+
+module.exports = async (req, res, next) => {
+    try {
+        const joinRequests = await joinUsModel.find();
+        res.status(200).json(joinRequests);
+    } catch (err) {
+        next(err);
+    }
+}

--- a/backend/app/routes/joinUs/index.js
+++ b/backend/app/routes/joinUs/index.js
@@ -6,7 +6,6 @@ const validation = require('../../../helpers/middlewares/validation');
 const {authMiddleware} = require('../../../helpers/middlewares/auth')
 
 router.post('/', validation(JoinUsValidationSchema), postJoinUs);
-// router.get('/', authMiddleware, getJoinUs);
-router.get('/', getJoinUs);
+router.get('/', authMiddleware, getJoinUs);
 
 module.exports = router;

--- a/backend/app/routes/joinUs/index.js
+++ b/backend/app/routes/joinUs/index.js
@@ -1,8 +1,12 @@
 const router = require('express').Router({ mergeParams: true });
 const postJoinUs = require('./post');
+const getJoinUs = require('./get');
 const JoinUsValidationSchema = require('./@validationSchema');
 const validation = require('../../../helpers/middlewares/validation');
+const {authMiddleware} = require('../../../helpers/middlewares/auth')
 
-router.post('/joinUs', validation(JoinUsValidationSchema), postJoinUs);
+router.post('/', validation(JoinUsValidationSchema), postJoinUs);
+// router.get('/', authMiddleware, getJoinUs);
+router.get('/', getJoinUs);
 
 module.exports = router;

--- a/backend/tests/routes/joinUs/getJoinUs.test.js
+++ b/backend/tests/routes/joinUs/getJoinUs.test.js
@@ -1,0 +1,46 @@
+const chai = require('chai');
+const { expect } = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../../../index');
+
+chai.use(chaiHttp);
+
+describe('Test for get join us requests:', () => {
+  let token = '';
+
+  // Step 1 - login as admin
+  it('log in as admin at /auth/login', (done) => {
+    const loginData = {
+      email: 'kajolkumarisingh222@gmail.com',
+      password: 'password',
+    };
+
+    chai
+      .request(server)
+      .post('/auth/login')
+      .send(loginData)
+      .then((res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body.email).to.equal(loginData.email);
+        expect(res.body.isSuperAdmin).to.equal(true);
+        expect(res.body.token).to.be.a('string');
+        token = res.body.token;
+        done();
+      })
+      .catch(done);
+  });
+
+  // Step 2 - get join us requests
+  it('get join us requests from db from /joinus', (done) => {
+    chai
+      .request(server)
+      .get('/joinUs')
+      .set('Authorization', `Bearer ${token}`)
+      .then((res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array');
+        done();
+      })
+      .catch(done);
+  });
+});


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #680

## Proposed changes

- Added GET API to allow admins get join us requests.
- Test the API endpoint.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.
