### PR TITLE
get admin details implemented on endpoint /admin

### DIFF
--- a/backend/app/routes/admin/@validationSchema/index.js
+++ b/backend/app/routes/admin/@validationSchema/index.js
@@ -18,7 +18,7 @@ const postSuperAdminSchema = Joi.object({
 const getAdminsSchema = Joi.object({
   type: Joi.string()
     .optional()
-    .pattern(/^(superAdmin|admin)$/),
+    .pattern(/^(superAdmin|admin|self)$/),
   page: Joi.number().optional(),
 });
 

--- a/backend/app/routes/admin/getAdmins.js
+++ b/backend/app/routes/admin/getAdmins.js
@@ -26,6 +26,13 @@ const getAdminsAggregate = (match, page) => {
 module.exports = async (req, res, next) => {
   const page = req.query.page || 1;
   const adminType = req.query.type;
+
+  if(adminType === 'admin'){
+    const adminDetails = await Admin.find({email: req.body.email});
+    res.json(adminDetails[0]);
+    return next();
+  }
+
   let match = {};
   if (adminType) {
     match = {

--- a/backend/app/routes/admin/getAdmins.js
+++ b/backend/app/routes/admin/getAdmins.js
@@ -30,11 +30,11 @@ module.exports = async (req, res, next) => {
   console.log(adminType);
   if (adminType === 'superAdmin') {
     match = {
-      isSuperAdmin: adminType === 'superAdmin',
+      isSuperAdmin: true,
     };
-  } else if (adminType === 'self'){
+  } else if (adminType === 'self') {
     match = {
-      email: adminType === 'self' ? req.body.email : '',
+      email: req.body.email || '',
     };
   }
 

--- a/backend/app/routes/admin/getAdmins.js
+++ b/backend/app/routes/admin/getAdmins.js
@@ -27,7 +27,6 @@ module.exports = async (req, res, next) => {
   const page = req.query.page || 1;
   const adminType = req.query.type;
   let match = {};
-  console.log(adminType);
   if (adminType === 'superAdmin') {
     match = {
       isSuperAdmin: true,
@@ -37,8 +36,6 @@ module.exports = async (req, res, next) => {
       email: req.body.email || '',
     };
   }
-
-  console.log(match);
   const [err, response] = await to(Admin.aggregate(getAdminsAggregate(match, page)));
   if (err) {
     const error = new ErrorHandler(constants.ERRORS.DATABASE, {

--- a/backend/app/routes/admin/getAdmins.js
+++ b/backend/app/routes/admin/getAdmins.js
@@ -26,19 +26,19 @@ const getAdminsAggregate = (match, page) => {
 module.exports = async (req, res, next) => {
   const page = req.query.page || 1;
   const adminType = req.query.type;
-
-  if(adminType === 'admin'){
-    const adminDetails = await Admin.find({email: req.body.email});
-    res.json(adminDetails[0]);
-    return next();
-  }
-
   let match = {};
-  if (adminType) {
+  console.log(adminType);
+  if (adminType === 'superAdmin') {
     match = {
       isSuperAdmin: adminType === 'superAdmin',
     };
+  } else if (adminType === 'self'){
+    match = {
+      email: adminType === 'self' ? req.body.email : '',
+    };
   }
+
+  console.log(match);
   const [err, response] = await to(Admin.aggregate(getAdminsAggregate(match, page)));
   if (err) {
     const error = new ErrorHandler(constants.ERRORS.DATABASE, {


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #476 

## Proposed changes
added simple if the check for adminType and fetched the details of admin using email attacked with the request body.

### Brief description of what is fixed or changed
endpoint /admin now returns single logged-in admin details for non-super admins
## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots
![image](https://user-images.githubusercontent.com/32095032/157844698-9869db81-cc71-422d-807d-be732dd184cf.png)

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
# Consider it under GSSOC`22
