### PR TITLE
Added API for getting all broadcasts

### DIFF
--- a/backend/app/routes/broadcast/getallbroadcasts.js
+++ b/backend/app/routes/broadcast/getallbroadcasts.js
@@ -1,0 +1,19 @@
+const Broadcast = require('../../models/Broadcast');
+const to = require('await-to-js').default;
+const constants = require('../../../constants');
+const { ErrorHandler } = require('../../../helpers/error');
+
+module.exports = async (req, res, next) => {
+  const [err, response] = await to(Broadcast.find());
+  if (err) {
+    const error = new ErrorHandler(constants.ERRORS.DATABASE, {
+      statusCode: 500,
+      message: 'Mongo Error: Fetching Failed',
+      errStack: err,
+    });
+    return next(error);
+  }
+
+  res.status(200).json(response);
+  next();
+};

--- a/backend/app/routes/broadcast/index.js
+++ b/backend/app/routes/broadcast/index.js
@@ -6,9 +6,9 @@ const { postBroadcastValidationSchema, getBroadcastsValidationSchema } = require
 const postBroadcast = require('./postBroadcast');
 const deleteBroadcast = require('./deleteBroadcast');
 const getBroadcasts = require('./getBroadcasts');
-
+const getallbroadcast = require('./getallbroadcasts');
 router.get('/', validationMiddleware(getBroadcastsValidationSchema, 'query'), getBroadcasts);
 router.post('/', validationMiddleware(postBroadcastValidationSchema), authMiddleware, postBroadcast);
 router.delete('/:id', authMiddleware, deleteBroadcast);
-
+router.get('/all', getallbroadcast);
 module.exports = router;

--- a/backend/tests/routes/broadcast/getAllBroadcasts.test.js
+++ b/backend/tests/routes/broadcast/getAllBroadcasts.test.js
@@ -1,0 +1,20 @@
+const chai = require('chai');
+const { expect } = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../../../index');
+
+chai.use(chaiHttp);
+
+// Test for get Broadcasts
+describe('Test for get all Broadcasts:', () => {
+  it('get all broadcasts from DB at /broadcast/all', (done) => {
+    chai
+      .request(server)
+      .get(`/broadcast/all`)
+      .then((res) => {
+        expect(res.status).to.equal(200);
+        done();
+      })
+      .catch(done);
+  });
+});

--- a/frontend/src/pages/Broadcast/Component/AllBroadcasts/AllBroadcasts.jsx
+++ b/frontend/src/pages/Broadcast/Component/AllBroadcasts/AllBroadcasts.jsx
@@ -76,7 +76,7 @@ export function AllBroadcasts(props) {
       api.replace("&month=", "");
     }
     if (tags === "" && page === "" && year === "" && month === "") {
-      api = `${END_POINT}/broadcast`;
+      api = `${END_POINT}/broadcast/all`;
     }
     return fetch(api, {
       method: "GET",


### PR DESCRIPTION
Added new route for above API as broadcast/all
Added test for this API
Introduce this route at client side when al filters are empty

## Issue that this pull request solves

 Closes: #753

## Proposed changes
Added API for getting all broadcasts

### Brief description of what is fixed or changed
Before even when no filters were applied only 5 broadcasts were sent from backend
This was due to "limit"  set to 5
This new API at route "broadcast/all" has no limit and sends all broadcasts
This API will be called only when no tags/filters are applied 
## Types of changes

_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
 Here is video recording showing working of this API
It also shows difference
-> "/broadcast/"  returning only 5 broadcasts even when no filters are applied
-> "broadcast/all" returning all broadcasts in DB"

Link: https://www.recordjoy.com/view/JvEC7Rgzh7Nmtkf6HUNO