### PR TITLE
Added End-Point For Deleting The Admin

### DIFF
--- a/backend/app/routes/admin/@validationSchema/index.js
+++ b/backend/app/routes/admin/@validationSchema/index.js
@@ -47,6 +47,10 @@ const updateAdminSchema =Joi.object({
   lastName:Joi.string(),
   contact:Joi.string().regex(/[+]91[6-9]{1}[0-9]{9}$/, 'phone'),
   username:Joi.string(),
+});
+
+const deleteAdminSchema = Joi.object({
+  id : Joi.string().min(24).max(24).required()
 })
 
 module.exports = {
@@ -57,4 +61,5 @@ module.exports = {
   forgotPasswordSchema,
   resetPasswordSchema,
   updateAdminSchema,
+  deleteAdminSchema
 };

--- a/backend/app/routes/admin/deleteAdmin.js
+++ b/backend/app/routes/admin/deleteAdmin.js
@@ -1,0 +1,45 @@
+const { default: to } = require("await-to-js");
+const constants = require("../../../constants");
+const { ErrorHandler } = require("../../../helpers/error");
+const Admin = require("../../models/Admin");
+
+module.exports = async (req, res, next) => {
+    const { isSuperAdmin } = res.locals.decode;
+
+    if(!isSuperAdmin) {
+        const error = new ErrorHandler(constants.ERRORS.INPUT, {
+            statusCode: 401,
+            message: 'Unauthorized Request: Not a superAdmin',
+            user: req.body.email,
+        });
+
+        return next(error);
+    }
+
+    const id = req.body.id;
+
+    const [err, admin] = await to(Admin.findByIdAndDelete(id));
+
+    if (!admin) {
+      const error = new ErrorHandler(constants.ERRORS.INPUT, {
+        statusCode: 400,
+        message: "Admin doesn't exist",
+      });
+
+      return next(error);
+    }
+
+    if (err) {
+      const error = new ErrorHandler(constants.ERRORS.DATABASE, {
+        statusCode: 500,
+        message: 'Mongo Error: Deletion Failed',
+        errStack: err,
+      });
+
+      return next(error);
+    }
+
+    return res.status(200).send({
+      message: 'Admin deleted successfully',
+    });    
+}

--- a/backend/app/routes/admin/index.js
+++ b/backend/app/routes/admin/index.js
@@ -10,6 +10,7 @@ const {
   forgotPasswordSchema,
   resetPasswordSchema,
   updateAdminSchema,
+  deleteAdminSchema,
 } = require('./@validationSchema');
 const createSuperAdmin = require('./createSuperAdmin');
 const postSuperAdmin = require('./postSuperAdmin');
@@ -20,6 +21,7 @@ const changePassword = require('./changePassword');
 const forgotPassword = require('./forgotPassword');
 const resetPassword = require('./resetPassword');
 const updateAdmin = require('./updateAdmin');
+const deleteAdmin = require('./deleteAdmin');
 
 router.get('/', validationMiddleware(getAdminsSchema, 'query'), authMiddleware, getAdmins);
 router.get('/createSuperAdmin', createSuperAdmin);
@@ -33,5 +35,6 @@ router.post('/resetpassword/:token', validationMiddleware(resetPasswordSchema), 
 router.put('/password', validationMiddleware(passwordChangeSchema), authMiddleware, changePassword);
 router.put('/:id/:token', validationMiddleware(updateAdminSchema), updateAdmin);
 
+router.delete('/deleteAdmin', validationMiddleware(deleteAdminSchema), authMiddleware, deleteAdmin);
 
 module.exports = router;

--- a/backend/tests/routes/admin/deleteAdmin.test.js
+++ b/backend/tests/routes/admin/deleteAdmin.test.js
@@ -1,0 +1,92 @@
+const chai = require('chai');
+const { expect } = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../../../index');
+
+chai.use(chaiHttp);
+
+// Test for delete Admin
+describe("Test For Delete Admin : ", () => {
+    let token = '';
+    let id = '';
+
+    //Step 1 - login as super admin
+    it('log in as admin at /auth/login', (done) => {
+        const loginData = {
+          email: 'kajolkumarisingh222@gmail.com',
+          password: 'password',
+        };
+    
+        chai
+          .request(server)
+          .post('/auth/login')
+          .send(loginData)
+          .then((res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body.email).to.equal(loginData.email);
+            expect(res.body.isSuperAdmin).to.equal(true);
+            expect(res.body.token).to.be.a('string');
+            token = res.body.token;
+            done();
+        })
+        .catch(done);
+    });
+
+    // Step 2 - Post The New Admin
+    it('Post admin at /admin', (done) => {
+        const adminData = {
+          email: 'demo-user@gmail.com',
+          password: 'demo@123-USER',
+          firstName : 'Demo',
+          lastName : 'User'
+        };
+    
+        chai
+          .request(server)
+          .post('/admin')
+          .set('Authorization', `Bearer ${token}`)
+          .send(adminData)
+          .then((res) => {
+            expect(res.status).to.equal(200);
+            id = res.body._id;
+            done();
+        })
+        .catch(done);
+    });
+
+    //Step 3 - Delete The Admin
+    it("Delete Admin At /admin/deleteAdmin", (done) => {
+        const data = {
+            id : id
+        };
+
+        chai
+            .request(server)
+            .delete('/admin/deleteAdmin')
+            .set('Authorization', `Bearer ${token}`)
+            .send(data)
+            .then((res) => {
+                expect(res.status).to.equal(200);
+                expect(res.body.message).to.be.equal("Admin deleted successfully")
+                done();
+            }).catch(done);
+    });
+    
+    //Step 4 - Delete Not Exist Admin
+    it("Delete Admin At /admin/deleteAdmin", (done) => {
+        const data = {
+            id : id
+        };
+
+        chai
+            .request(server)
+            .delete('/admin/deleteAdmin')
+            .set('Authorization', `Bearer ${token}`)
+            .send(data)
+            .then((res) => {
+                expect(res.status).to.equal(400);
+                expect(res.body.message).to.be.equal("Admin doesn't exist")
+                done();
+            }).catch(done);
+    });
+})


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #477

## Proposed changes

- Create a route to delete an admin. This can be performed only if the request is made by a SuperAdmin.

### Brief description of what is fixed or changed

- Added The <b>admin/deleteAdmin</b> end point for deleting the admin
- Also added the check for super admin
- Added The deleteAdmin.test.js for checking the functionality

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots


![image](https://user-images.githubusercontent.com/61725413/197838290-829a3398-b55b-404a-bd26-abb12c70af4c.png)


![image](https://user-images.githubusercontent.com/61725413/197838131-c6fc0cb3-b0a0-45da-8d6c-b10ceb077f52.png)
