### PR TITLE
Integrate GET Questions in Frontend

### DIFF
--- a/frontend/src/pages/Q&A/Q&A.jsx
+++ b/frontend/src/pages/Q&A/Q&A.jsx
@@ -193,6 +193,9 @@ function Ques(props) {
     });
 
     if (!response.ok) {
+      setToastMessage("Failed to upvote question");
+      setOpenToast(true);
+      setSeverity("error");
       throw new Error("Failed to upvote question");
     }
     // const data = await response.json();
@@ -212,7 +215,10 @@ function Ques(props) {
     });
 
     if (!response.ok) {
-      throw new Error("Failed to upvote question");
+      setToastMessage("Failed to downvote question");
+      setOpenToast(true);
+      setSeverity("error");
+      throw new Error("Failed to downvote question");
     }
     // const data = await response.json();
     // console.log(data);
@@ -224,9 +230,6 @@ function Ques(props) {
 
   useEffect(() => {
     getQues();
-    setToastMessage("Fetching Questions...");
-    setOpenToast(true);
-    setSeverity("success");
   }, []);
 
   return (

--- a/frontend/src/pages/Q&A/Q&A.jsx
+++ b/frontend/src/pages/Q&A/Q&A.jsx
@@ -7,7 +7,11 @@ import Joi from "joi-browser";
 import Loader from "../../components/util/Loader/index";
 import { SimpleToast } from "../../components/util/Toast";
 import { END_POINT } from "../../config/api";
-import { ErrorSharp } from "@material-ui/icons";
+import {
+  AirplayTwoTone,
+  ErrorSharp,
+  SettingsBluetoothSharp,
+} from "@material-ui/icons";
 
 function Ques(props) {
   let dark = props.theme;
@@ -59,6 +63,7 @@ function Ques(props) {
   const [checkedState, setCheckedState] = useState(
     new Array(Tags.length).fill(false)
   );
+  const [loading, setLoading] = useState(true);
 
   const [formdata, setFormData] = useState({
     title: "",
@@ -172,6 +177,7 @@ function Ques(props) {
     })
       .then((res) => res.json())
       .then((data) => {
+        setLoading(false);
         setQuestions(data);
         // console.log(data);
       });
@@ -191,6 +197,9 @@ function Ques(props) {
     }
     // const data = await response.json();
     getQues();
+    setToastMessage("Upvote Successfully");
+    setOpenToast(true);
+    setSeverity("success");
   };
 
   const downvote = async (questionId) => {
@@ -208,10 +217,16 @@ function Ques(props) {
     // const data = await response.json();
     // console.log(data);
     getQues();
+    setToastMessage("Downvote Successfully");
+    setOpenToast(true);
+    setSeverity("success");
   };
 
   useEffect(() => {
     getQues();
+    setToastMessage("Fetching Questions...");
+    setOpenToast(true);
+    setSeverity("success");
   }, []);
 
   return (
@@ -219,7 +234,9 @@ function Ques(props) {
       className="popup-creator"
       style={{ background: dark ? "#171717" : "white" }}
     >
-      {getQuestions.length >= 0 ? (
+      {getQuestions.length <= 0 ? (
+        <Loader></Loader>
+      ) : (
         <div className="question-cards">
           {getQuestions.map((item, key) => (
             <div className="question-card" key={key}>
@@ -251,8 +268,6 @@ function Ques(props) {
             </div>
           ))}
         </div>
-      ) : (
-        <Loader />
       )}
 
       <SimpleToast

--- a/frontend/src/pages/Q&A/Ques.scss
+++ b/frontend/src/pages/Q&A/Ques.scss
@@ -22,11 +22,72 @@
   border: 1px solid #69a9dd;
 }
 
+.question-cards {
+  width: 100%;
+  height: auto;
+  color: white;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 40px;
+  padding: 40px 40px 40px 40px;
+}
+
+.question-card {
+  width: 350px;
+  height: auto;
+  background: #282c35;
+  border-radius: 10px;
+  border: 1px solid white;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.card-up {
+  padding: 10px;
+}
+
+.card-down {
+  width: 100%;
+  height: auto;
+  background-color: #243e74;
+  color: white;
+  padding: 10px;
+  border-top: 1px solid white;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+}
+
+.card-down p {
+  margin: 0;
+}
+
+.vote-btn {
+  background-color: #69a9dd;
+  outline: 1px solid white;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  padding: 5px;
+  margin: 5px;
+  cursor: pointer;
+}
+
 @media (max-width: 650px) {
   .question_form {
     width: 85%;
 
     margin: 5% 5% 5% 5%;
+  }
+}
+@media (max-width: 400px) {
+  .question-cards {
+    padding: 40px 10px 40px 10px;
+  }
+  .question-card {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
 Closes: #784 

## Brief description of what is fixed or changed
We have get all questions in the the backend and also the questions has the upvote and downvote so i integrated in the frontend and added the UI for the question cards. 

## Types of changes
- [x] As soon as someone visits on Q&A page, there should be the [GET Questions](https://github.com/HITK-TECH-Community/Community-Website/blob/main/backend/app/routes/Q%26A/question/getAllQuestion.js) call.
- [x] The upvote functionality is integrated in frontend and downvote Also.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

https://github.com/HITK-TECH-Community/Community-Website/assets/113225478/d098078e-4861-4694-9c62-b36b608f647b

![questioncard](https://github.com/HITK-TECH-Community/Community-Website/assets/113225478/5c887e4a-f13b-44f3-bba4-b7f98df8f016)

## Other Information
Please clear the test questions from mongodb database.
