### PR TITLE
submit button in Q&A page corrected

### DIFF
--- a/frontend/src/pages/Q&A/Q&A.jsx
+++ b/frontend/src/pages/Q&A/Q&A.jsx
@@ -124,10 +124,17 @@ function Ques(props) {
         body: JSON.stringify(formdata),
       });
       const data = await response.json();
+      if(data.errStack){
+        setToastMessage(`${data.errStack}`);
+        setOpenToast(true);
+        setSeverity("error");
+      }else{
+        setToastMessage("Q&A added successfully!");
+        setOpenToast(true);
+        setSeverity("success");
+      }
       setIsUploadingData(false);
-      setToastMessage("Q&A added successfully!");
-      setOpenToast(true);
-      setSeverity("success");
+     
       setFormData({
         title: "",
         description: "",
@@ -421,14 +428,13 @@ function Ques(props) {
                 style={{ justifyContent: "space-around" }}
               >
                 <div className="data-loader">
-                  {isUploadingData ? <Loader /> : null}
-                </div>
-                <Button2
+                  {isUploadingData ? <Loader /> :  <Button2
                   style={{ marginRight: "3%" }}
                   className={style["submit-btn-text"]}
                   label="Submit"
                   type="submit"
-                />
+                />}
+                </div>
               </div>
             </div>
           </form>

--- a/frontend/src/pages/Q&A/Ques.scss
+++ b/frontend/src/pages/Q&A/Ques.scss
@@ -94,7 +94,7 @@
 .data-loader {
   width: 100%;
   display: flex;
-  height: 10px;
+  height: 60px;
   justify-content: center;
   align-items: center;
 }


### PR DESCRIPTION
## Issue that this pull request solves
submit button in Q&A page corrected 
 Closes: #700 

## Proposed changes
submit button responsive .
and correct the toast. Q&A showing submitted toast even it is not -like when we enter characters less then 5 it still shows toast submitted.
### Brief description of what is fixed or changed
submit button responsive earlier data loader was taking space now if submit is clicked data loader will come in place of submit button
and if response contains errStack then error toast will be shown
## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots
**submit button responsive**
![331139491-4d78664f-507c-4463-b395-508a73fe8e38](https://github.com/HITK-TECH-Community/Community-Website/assets/122097724/086b4001-d3cb-4283-9fee-907d4da66e38)
![331140342-94a5bbae-02a3-42bf-b2f3-472c582ca032](https://github.com/HITK-TECH-Community/Community-Website/assets/122097724/213ef558-253c-4105-b49f-9ebf4a84ff36)
**error msg**
![331140453-67acb80e-a227-46f1-8e67-ef5e8bae611c](https://github.com/HITK-TECH-Community/Community-Website/assets/122097724/7c0e31e0-913a-465d-9fd7-3c5eb41d049c)

## Other information

Any other information that is important to this pull request
