### PR TITLE
getAdmin api updated to send id also

### DIFF
--- a/backend/app/routes/admin/getAdmins.js
+++ b/backend/app/routes/admin/getAdmins.js
@@ -8,7 +8,7 @@ const getAdminsAggregate = (match, page) => {
     { $match: match },
     {
       $project: {
-        _id: 0,
+        _id: 1,
         firstName: 1,
         lastName: 1,
         username: 1,


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #915 

## Proposed changes
getAdmin api updated to send id also
### Brief description of what is fixed or changed
Earlier getAdmin api was not sending _id that is required for updateAdmin
## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
