### PR TITLE
[Backend] The DELETE teamMemebers API should also delete the respective file stored in the disk Fixed

### DIFF
--- a/backend/app/routes/teamMember/deleteTeamMember.js
+++ b/backend/app/routes/teamMember/deleteTeamMember.js
@@ -1,19 +1,33 @@
 const teamMemberModel = require('../../models/TeamMember');
-module.exports = async(req,res,next) => {
-    try {
-        const payload = res.locals.decode;
-        const memberId = req.body.memberId;
-        if (payload.isSuperAdmin === false) {
-            return res.status(401).json({ error: 'You are not an admin' });
-        }
-        const result = await teamMemberModel.findByIdAndDelete(memberId);
-        if(!result) {
-            return res.status(401).json({error:"Invalid id"});
-        }
-        return res.json({message:"Deleted successfully"});
+const fs = require('fs');
+const path = require('path');
+
+module.exports = async (req, res, next) => {
+  try {
+    const payload = res.locals.decode;
+    const memberId = req.body.memberId;
+
+    if (payload.isSuperAdmin === false) {
+      return res.status(401).json({ error: 'You are not an admin' });
     }
-    catch(error) {
-        return res.status(500).json({error:"Some internal server error"});
+
+    const member = await teamMemberModel.findById(memberId);
+    if (!member) {
+      return res.status(401).json({ error: 'Invalid id' });
     }
-    
-}
+
+    const result = await teamMemberModel.findByIdAndDelete(memberId);
+    if (!result) {
+      return res.status(401).json({ error: 'Invalid id' });
+    }
+
+    const fileName = path.basename(member.image);
+    const imagePath = path.join(__dirname, '../../../uploads/teamMembersProfile/', fileName);
+    fs.unlink(imagePath, (err) => console.log(err));
+
+    return res.json({ message: 'Deleted successfully' });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: 'Some internal server error' });
+  }
+};

--- a/backend/app/routes/teamMember/deleteTeamMember.js
+++ b/backend/app/routes/teamMember/deleteTeamMember.js
@@ -6,25 +6,18 @@ module.exports = async (req, res, next) => {
   try {
     const payload = res.locals.decode;
     const memberId = req.body.memberId;
-
     if (payload.isSuperAdmin === false) {
       return res.status(401).json({ error: 'You are not an admin' });
     }
-
-    const member = await teamMemberModel.findById(memberId);
-    if (!member) {
-      return res.status(401).json({ error: 'Invalid id' });
-    }
-
     const result = await teamMemberModel.findByIdAndDelete(memberId);
     if (!result) {
       return res.status(401).json({ error: 'Invalid id' });
     }
-
-    const fileName = path.basename(member.image);
-    const imagePath = path.join(__dirname, '../../../uploads/teamMembersProfile/', fileName);
-    fs.unlink(imagePath, (err) => console.log(err));
-
+    if (result?.image) {
+      const fileName = path.basename(result.image);
+      const imagePath = path.join(__dirname, '../../../uploads/teamMembersProfile/', fileName);
+      fs.unlink(imagePath, (err) => console.log(err));
+    }
     return res.json({ message: 'Deleted successfully' });
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Issue that this pull request solves
[Issue Link](https://github.com/HITK-TECH-Community/Community-Website/issues/916) resolve #916 

 Closes: #916 


### Brief description of what is fixed or changed
The delete call should also delete the image file before deleting the data form the DB. added in the delete function.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes does not break the current system and it passes all the current test cases.

## Screenshots or video

https://github.com/HITK-TECH-Community/Community-Website/assets/106808387/003550b3-b761-4eb7-b5e5-98ce58c0fcbe

