### PR TITLE
Integrate-Answers-in-QA-Page - Added Small Code

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,4 +1,4 @@
-MONGO_DB_URL=<mongoDB_URL>
+MONGO_DB_URL=mongodb://localhost:27017/testdb
 JWT_SECRET_KEY=<JWT_sceret>
 JWT_EXPIRES_IN=6h
 BASE_URL=https://community-website-backend.herokuapp.com

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -36,6 +36,7 @@ import { Broadcast } from "./pages/Broadcast/index";
 import { AllBroadcasts } from "./pages/Broadcast/Component/AllBroadcasts/index";
 import { GetInvolved } from "./pages/GetInvolved";
 import { ForgotPasswordRecovery } from "./pages/ForgotPasswordRecovery/index";
+import GetAnswer from "./pages/Q&A/Components/GetAnswer/GetAnswer.jsx";
 
 import { useSelector } from "react-redux";
 
@@ -131,6 +132,11 @@ const App = () => {
                 exact={true}
                 path="/Q&A"
                 render={() => <Ques theme={theme} />}
+              />
+              <Route
+                exact={true}
+                path="/getanswers/:answerId"
+                render={() => <GetAnswer theme={theme} />}
               />
               <Route
                 exact={true}

--- a/frontend/src/pages/Q&A/Components/GetAnswer/GetAnswer.jsx
+++ b/frontend/src/pages/Q&A/Components/GetAnswer/GetAnswer.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect } from "react";
+import { useState } from "react";
+import "./GetAnswer.scss";
+import "../../../Q&A/Ques.scss";
+import { END_POINT } from "../../../../config/api";
+import { useParams } from "react-router-dom";
+
+function GetAnswer() {
+  const { answerId } = useParams();
+  // console.log(answerId);
+
+  const [answer, setAnswer] = useState([]);
+
+  //Get Answer
+  const GetAnswer = (answerId) => {
+    try {
+      fetch(`${END_POINT}/answers/${answerId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          console.log(data);
+          setAnswer(data.data);
+        });
+    } catch (error) {
+      console.error("Error fetching answer:", error);
+    }
+  };
+  useEffect(() => {
+    GetAnswer(answerId);
+  }, []);
+
+  console.log(answer);
+
+  return (
+    <>
+      <div className="main">
+        <div className="question">question</div>
+        <div className="answers">
+          {answer.length > 0 ? (
+            answer.map((item, key) => (
+              <div className="question-cards" key={key}>
+                <div className="question-card">
+                  <div className="card-up">
+                    <p>{item.answer}</p>
+                    <span className="tag-space">#</span>
+                  </div>
+                  <div className="card-down">
+                    <div>
+                      <p>
+                        Created At {new Date(item.createdAt).toLocaleString()}
+                      </p>
+                      <p>Created By {item.created_by}</p>
+                    </div>
+                    <div>
+                      <button className="vote-btn">👍</button>
+                      <button className="vote-btn">👎</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <h1>No Answer</h1>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+export default GetAnswer;

--- a/frontend/src/pages/Q&A/Components/GetAnswer/GetAnswer.scss
+++ b/frontend/src/pages/Q&A/Components/GetAnswer/GetAnswer.scss
@@ -1,0 +1,9 @@
+.main {
+  height: 100vh;
+  width: 100%;
+  background-color: #171717;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/frontend/src/pages/Q&A/Q&A.jsx
+++ b/frontend/src/pages/Q&A/Q&A.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { Link } from "react-router-dom";
 import { Button2, Button1 } from "../../components/util/Button";
 import style from "../Resources/components/ResourceSharingForm/resource-sharing-form.module.scss";
 import "./Ques.scss";
@@ -7,11 +8,6 @@ import Joi from "joi-browser";
 import Loader from "../../components/util/Loader/index";
 import { SimpleToast } from "../../components/util/Toast";
 import { END_POINT } from "../../config/api";
-import {
-  AirplayTwoTone,
-  ErrorSharp,
-  SettingsBluetoothSharp,
-} from "@material-ui/icons";
 
 function Ques(props) {
   let dark = props.theme;
@@ -124,17 +120,17 @@ function Ques(props) {
         body: JSON.stringify(formdata),
       });
       const data = await response.json();
-      if(data.errStack){
+      if (data.errStack) {
         setToastMessage(`${data.errStack}`);
         setOpenToast(true);
         setSeverity("error");
-      }else{
+      } else {
         setToastMessage("Q&A added successfully!");
         setOpenToast(true);
         setSeverity("success");
       }
       setIsUploadingData(false);
-     
+
       setFormData({
         title: "",
         description: "",
@@ -272,6 +268,9 @@ function Ques(props) {
                     onClick={() => downvote(item._id)}
                   >
                     👎 {item.downvote}
+                  </button>
+                  <button>
+                    <Link to={`/getanswers/${item._id}`}>Get Answer</Link>
                   </button>
                 </div>
               </div>
@@ -428,12 +427,16 @@ function Ques(props) {
                 style={{ justifyContent: "space-around" }}
               >
                 <div className="data-loader">
-                  {isUploadingData ? <Loader /> :  <Button2
-                  style={{ marginRight: "3%" }}
-                  className={style["submit-btn-text"]}
-                  label="Submit"
-                  type="submit"
-                />}
+                  {isUploadingData ? (
+                    <Loader />
+                  ) : (
+                    <Button2
+                      style={{ marginRight: "3%" }}
+                      className={style["submit-btn-text"]}
+                      label="Submit"
+                      type="submit"
+                    />
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Closes: #885 (Draft PR)

## Proposed changes
Currently the Q&A page only have the question list and form to submit the questions. There should be a way to see all the answers of the particular question sorted by the number of upvotes

### Brief description of what is fixed or changed
Added The Answer Page For Specific Question When  User Clicks On The Get Answer Button

## Types of changes

- [x] Integrating Front End Answer For Specific Question. (Non -Breaking Changes)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots
Added Button In Question Card :
![Answer Added](https://github.com/HITK-TECH-Community/Community-Website/assets/113225478/b55b105d-a34f-4b6a-8b2f-167971ef9c9f)

Answer Page For Specific Question By User IDs : 
![answerpage](https://github.com/HITK-TECH-Community/Community-Website/assets/113225478/8b3f04e1-2b0d-4703-83bb-f81a847a510c)

## Other information

There Answer In Past Days But They Deleted The Answers And Question Also So I Will Work On The Issue  #886 And Then Back To This 😁
