### PR TITLE
[Backend] Auth remove for post contact us Fixed

### DIFF
--- a/backend/app/routes/contactUs/get.js
+++ b/backend/app/routes/contactUs/get.js
@@ -4,6 +4,10 @@ const { ErrorHandler } = require('../../../helpers/error');
 const constants = require('../../../constants');
 
 module.exports = async (req, res, next) => {
+  const payload = res.locals.decode;
+  if (!payload.isSuperAdmin) {
+    return res.status(401).json({ error: 'You are not authorized to perform this action' });
+  }
   const [err, response] = await to(contactUs.find());
   if (err) {
     const error = new ErrorHandler(constants.ERRORS.DATABASE, {

--- a/backend/app/routes/contactUs/index.js
+++ b/backend/app/routes/contactUs/index.js
@@ -7,7 +7,7 @@ const deleteContactUs = require('./delete');
 const { authMiddleware } = require('../../../helpers/middlewares/auth');
 
 router.get('/getcontactus', getContact);
-router.post('/',authMiddleware, validation(contactValidationSchema), postContact);
+router.post('/', validation(contactValidationSchema), postContact);
 router.delete("/deleteContactUs",authMiddleware, deleteContactUs);
 
 module.exports = router;

--- a/backend/app/routes/contactUs/index.js
+++ b/backend/app/routes/contactUs/index.js
@@ -6,8 +6,8 @@ const getContact = require('./get');
 const deleteContactUs = require('./delete');
 const { authMiddleware } = require('../../../helpers/middlewares/auth');
 
-router.get('/getcontactus', getContact);
+router.get('/getcontactus', authMiddleware, getContact);
 router.post('/', validation(contactValidationSchema), postContact);
-router.delete("/deleteContactUs",authMiddleware, deleteContactUs);
+router.delete('/deleteContactUs', authMiddleware, deleteContactUs);
 
 module.exports = router;


### PR DESCRIPTION
## Issue that this pull request solves

[Issue Link](https://github.com/HITK-TECH-Community/Community-Website/issues/957) resolve #957 
 Closes: #957 

### Brief description of what is fixed or changed
Post contact us doesn't need auth, why because user post the data using contact us. Because of authentication user unable to post the data from contact us page. Now post contact us works fine.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes does not break the current system and it passes all the current test cases.
