### PR TITLE
[Refactor] Frontend API Calls should be kept under the Service folder for contact us Fixed

### DIFF
--- a/frontend/src/common/constants.js
+++ b/frontend/src/common/constants.js
@@ -1,0 +1,10 @@
+const POST_SUCCUSS = "Successfully Post data!";
+const POST_FAIL = "Unable to post data!";
+const GET_SUCCESS = "Successfully get data!";
+const GET_FAIL = "Unable to get data!";
+const PATCH_SUCCESS = "Successfully Updated data!";
+const PATCH_FAIL = "Unable to Update data!";
+const DELETE_SUCCESS = "Successfully Delete data!";
+const DELETE_FAIL = "Unable to delete data!";
+
+export { POST_SUCCUSS, POST_FAIL, GET_SUCCESS, GET_FAIL, PATCH_SUCCESS, PATCH_FAIL, DELETE_SUCCESS, DELETE_FAIL };

--- a/frontend/src/pages/Admin/Components/Contact/Contact.jsx
+++ b/frontend/src/pages/Admin/Components/Contact/Contact.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { END_POINT } from "../../../../config/api";
 import { useEffect, useState } from "react";
 import Grid from "@material-ui/core/Grid";
 import { Card } from "./Card/index.js";
 import style from "./contactus.module.scss";
 import Loader from "../../../../components/util/Loader";
 import { SimpleToast } from "../../../../components/util/Toast/Toast.jsx";
+import { deleteContactUs, getContactUs } from "../../../../service/ContactUs.jsx";
 
 export function Contact() {
   const [contactUsData, setContactUsData] = useState([]);
@@ -18,15 +18,8 @@ export function Contact() {
   const fetchJoinUs = async () => {
     setIsLoaded(true);
     try{
-    const response = await fetch(`${END_POINT}/contactus/getcontactus`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${localStorage.getItem("token")}`,
-      },
-    });
-    const data = await response.json();
-    setContactUsData(data.ContactUs);
+    const data = await getContactUs();
+    setContactUsData(data);
     setToast({
         ...toast,
         toastMessage: "Successfully get data!",
@@ -51,17 +44,7 @@ export function Contact() {
   };
   const handleDelete = async (id) => {
     try {
-      const url = `${END_POINT}/contactus/deleteContactUs`;
-      const response = await fetch(url, {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify({ contactUsId: id }),
-      });
-
-      const data = await response.json();
+      const data = await deleteContactUs(id);
       setToast({
         ...toast,
         toastMessage: "Successfully deleted!",

--- a/frontend/src/pages/Admin/Components/Contact/Contact.jsx
+++ b/frontend/src/pages/Admin/Components/Contact/Contact.jsx
@@ -17,23 +17,8 @@ export function Contact() {
   });
   const fetchJoinUs = async () => {
     setIsLoaded(true);
-    try{
-    const data = await getContactUs();
+    const data = await getContactUs(setToast, toast);
     setContactUsData(data);
-    setToast({
-        ...toast,
-        toastMessage: "Successfully get data!",
-        toastStatus: true,
-        toastType: "success",
-      });
-    }catch(error){
-      setToast({
-        ...toast,
-        toastMessage: "Unable to get data!",
-        toastStatus: true,
-        toastType: "error",
-      });
-    }
     setIsLoaded(false);
   };
   const handleCloseToast = (event, reason) => {
@@ -43,24 +28,8 @@ export function Contact() {
     setToast({ ...toast, toastStatus: false });
   };
   const handleDelete = async (id) => {
-    try {
-      const data = await deleteContactUs(id);
-      setToast({
-        ...toast,
-        toastMessage: "Successfully deleted!",
-        toastStatus: true,
-        toastType: "success",
-      });
+      const data = await deleteContactUs(id, setToast, toast);
       fetchJoinUs()
-    } catch (error) {
-      console.log(error);
-      setToast({
-        ...toast,
-        toastMessage: "Unable to delete!",
-        toastStatus: true,
-        toastType: "error",
-      });
-    }
   };
   useEffect(() => {
     setIsLoaded(true);

--- a/frontend/src/pages/ContactUs/ContactUs.jsx
+++ b/frontend/src/pages/ContactUs/ContactUs.jsx
@@ -3,16 +3,15 @@ import { Button2 } from "../../components/util/Button/index";
 import Recaptcha from "react-recaptcha";
 import style from "./ContactUs.module.scss";
 import Joi from "joi-browser";
-import { END_POINT } from "../../config/api";
 import { SimpleToast } from "../../components/util/Toast/index";
 import Loader from "../../components/util/Loader";
+import { postContactUs } from "../../service/ContactUs";
 
 export const ContactUs = (props) => {
   const [isVerified, verified] = useState(false);
   const [contactToast, setContactToast] = useState("");
-  const [openSubmitContactSuccess, setOpenSubmitContactSuccess] = useState(
-    false
-  );
+  const [openSubmitContactSuccess, setOpenSubmitContactSuccess] =
+    useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [contactToastStatus, setContactToastStatus] = useState("");
   const recaptchaLoaded = () => {
@@ -91,34 +90,27 @@ export const ContactUs = (props) => {
     setFormErrors(errors);
   };
   const submitContactFormData = async (formData) => {
-    var api = `${END_POINT}/contactus`;
     setIsLoading(true);
-    return await fetch(api, {
-      method: "POST",
-      body: JSON.stringify(formData),
-      headers: {
-        "Content-type": "application/json",
-      },
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        if (
-          data.message === "Database Error" ||
-          data.message === "Sendgrid Error"
-        ) {
-          setIsLoading(false);
-          setContactToast(data.message);
-          setContactToastStatus("error");
-        } else {
-          setIsLoading(false);
-          setContactToastStatus("success");
-          setContactToast(data.message);
-          setOpenSubmitContactSuccess(true);
-        }
-      })
-      .catch((err) => {
-        console.info(err);
-      });
+    try {
+      const data = await postContactUs(formData);
+      if (
+        data.message === "Database Error" ||
+        data.message === "Sendgrid Error"
+      ) {
+        setIsLoading(false);
+        setContactToast(data.message);
+        setContactToastStatus("error");
+      } else {
+        setIsLoading(false);
+        setContactToastStatus("success");
+        setContactToast(data.message);
+        setOpenSubmitContactSuccess(true);
+      }
+    } catch (error) {
+      setIsLoading(false);
+      setContactToast("Server Error");
+      setContactToastStatus("error");
+    }
   };
   const handleCloseContactToast = () => {
     setOpenSubmitContactSuccess(false);

--- a/frontend/src/pages/ContactUs/ContactUs.jsx
+++ b/frontend/src/pages/ContactUs/ContactUs.jsx
@@ -9,11 +9,12 @@ import { postContactUs } from "../../service/ContactUs";
 
 export const ContactUs = (props) => {
   const [isVerified, verified] = useState(false);
-  const [contactToast, setContactToast] = useState("");
-  const [openSubmitContactSuccess, setOpenSubmitContactSuccess] =
-    useState(false);
+  const [toast, setToast] = useState({
+    toastStatus: false,
+    toastType: "",
+    toastMessage: "",
+  });
   const [isLoading, setIsLoading] = useState(false);
-  const [contactToastStatus, setContactToastStatus] = useState("");
   const recaptchaLoaded = () => {
     console.log("Recaptcha loaded");
   };
@@ -91,30 +92,14 @@ export const ContactUs = (props) => {
   };
   const submitContactFormData = async (formData) => {
     setIsLoading(true);
-    try {
-      const data = await postContactUs(formData);
-      if (
-        data.message === "Database Error" ||
-        data.message === "Sendgrid Error"
-      ) {
-        setIsLoading(false);
-        setContactToast(data.message);
-        setContactToastStatus("error");
-      } else {
-        setIsLoading(false);
-        setContactToastStatus("success");
-        setContactToast(data.message);
-        setOpenSubmitContactSuccess(true);
-      }
-    } catch (error) {
-      setIsLoading(false);
-      setContactToast("Server Error");
-      setContactToastStatus("error");
-    }
+    const data = await postContactUs(formData,setToast,toast);
+    setIsLoading(false);
   };
-  const handleCloseContactToast = () => {
-    setOpenSubmitContactSuccess(false);
-    setContactToast("");
+  const handleCloseContactToast = (event,reason) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setToast({ ...toast, toastStatus: false });
   };
   return (
     <div
@@ -140,7 +125,7 @@ export const ContactUs = (props) => {
                   <Loader height="25vh" />
                 </div>
               </React.Fragment>
-            ) : contactToastStatus === "error" ? (
+            ) : toast.toastStatus === "error" ? (
               <React.Fragment>
                 <div className={style["goodbye-card"]}>
                   <h1 className={style["card-heading"]}>OOPS !</h1>
@@ -312,12 +297,12 @@ export const ContactUs = (props) => {
           )}
         </div>
       </div>
-      {openSubmitContactSuccess && (
+      {toast.toastStatus && (
         <SimpleToast
-          open={openSubmitContactSuccess}
-          message={contactToast}
+          open={toast.toastStatus}
+          message={toast.toastMessage}
           handleCloseToast={handleCloseContactToast}
-          severity={contactToastStatus}
+          severity={toast.toastType}
         />
       )}
     </div>

--- a/frontend/src/service/ContactUs.jsx
+++ b/frontend/src/service/ContactUs.jsx
@@ -1,41 +1,90 @@
+import { DELETE_FAIL, DELETE_SUCCESS, GET_FAIL, GET_SUCCESS, POST_FAIL, POST_SUCCUSS } from "../common/constants";
 import { END_POINT } from "../config/api";
 
-const getContactUs = async () => {
-  const response = await fetch(`${END_POINT}/contactus/getcontactus`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
-    },
-  });
-  const data = await response.json();
-  return data.ContactUs;
+const getContactUs = async (setToast, toast) => {
+  try {
+    const response = await fetch(`${END_POINT}/contactus/getcontactus`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+    });
+    const data = await response.json();
+    setToast({
+      ...toast,
+      toastMessage: GET_SUCCESS,
+      toastStatus: true,
+      toastType: "success",
+    });
+    return data.ContactUs;
+  } catch (err) {
+    console.log(err);
+    setToast({
+      ...toast,
+      toastMessage: GET_FAIL,
+      toastStatus: true,
+      toastType: "error",
+    });
+  }
 };
 
-const postContactUs = async (data) => {
-  const response = await fetch(`${END_POINT}/contactus/`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
-  const _data = await response.json();
-  return _data;
+const postContactUs = async (data,setToast,toast) => {
+  try {
+    const response = await fetch(`${END_POINT}/contactus/`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+    const _data = await response.json();
+    setToast({
+      ...toast,
+      toastMessage: POST_SUCCUSS,
+      toastStatus: true,
+      toastType: "success",
+    });
+    return _data;
+  } catch (err) {
+    console.log(err);
+    setToast({
+      ...toast,
+      toastMessage: POST_FAIL,
+      toastStatus: true,
+      toastType: "error",
+    });
+  }
 };
 
-const deleteContactUs = async (id) => {
-  const response = await fetch(`${END_POINT}/contactus/deleteContactUs`, {
-    method: "DELETE",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
-    },
-    body: JSON.stringify({ contactUsId: id }),
-  });
+const deleteContactUs = async (id, setToast, toast) => {
+  try {
+    const response = await fetch(`${END_POINT}/contactus/deleteContactUs`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+      body: JSON.stringify({ contactUsId: id }),
+    });
 
-  const data = await response.json();
-  return data;
+    const data = await response.json();
+    setToast({
+      ...toast,
+      toastMessage: DELETE_SUCCESS,
+      toastStatus: true,
+      toastType: "success",
+    });
+    return data;
+  } catch (err) {
+    console.log(err);
+    setToast({
+      ...toast,
+      toastMessage: DELETE_FAIL,
+      toastStatus: true,
+      toastType: "error",
+    });
+  }
 };
 
 export { getContactUs, postContactUs, deleteContactUs };

--- a/frontend/src/service/ContactUs.jsx
+++ b/frontend/src/service/ContactUs.jsx
@@ -1,0 +1,41 @@
+import { END_POINT } from "../config/api";
+
+const getContactUs = async () => {
+  const response = await fetch(`${END_POINT}/contactus/getcontactus`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+    },
+  });
+  const data = await response.json();
+  return data.ContactUs;
+};
+
+const postContactUs = async (data) => {
+  const response = await fetch(`${END_POINT}/contactus/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  const _data = await response.json();
+  return _data;
+};
+
+const deleteContactUs = async (id) => {
+  const response = await fetch(`${END_POINT}/contactus/deleteContactUs`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+    },
+    body: JSON.stringify({ contactUsId: id }),
+  });
+
+  const data = await response.json();
+  return data;
+};
+
+export { getContactUs, postContactUs, deleteContactUs };


### PR DESCRIPTION
[Refactor] Frontend API Calls should be kept under the Service folder for contact us Fixed

## Issue that this pull request solves

[Issue Link](https://github.com/HITK-TECH-Community/Community-Website/issues/968) resolve #968 
 Closes: #968 

### Brief description of what is fixed or changed
Refactoring the  contact us page and make all api's related to contact us in a one file.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes does not break the current system and it passes all the current test cases.
