### PR TITLE
[Refactor] Frontend API Calls should be kept under the Service folder for Resources Fixed

### DIFF
--- a/frontend/src/service/Resources.jsx
+++ b/frontend/src/service/Resources.jsx
@@ -1,0 +1,97 @@
+import {
+  DELETE_FAIL,
+  DELETE_SUCCESS,
+  GET_FAIL,
+  GET_SUCCESS,
+  POST_FAIL,
+  POST_SUCCUSS,
+} from "../common/constants";
+import { END_POINT } from "../config/api";
+
+const getResources = async (setToast, toast) => {
+  try {
+    const response = await fetch(`${END_POINT}/resources/getresources`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+    });
+    const data = await response.json();
+    setToast({
+      ...toast,
+      toastMessage: GET_SUCCESS,
+      toastStatus: true,
+      toastType: "success",
+    });
+    return data.ContactUs;
+  } catch (err) {
+    console.log(err);
+    setToast({
+      ...toast,
+      toastMessage: GET_FAIL,
+      toastStatus: true,
+      toastType: "error",
+    });
+  }
+};
+
+const postResources = async (data, setToast, toast) => {
+  try {
+    const response = await fetch(`${END_POINT}/resources/`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+      body: JSON.stringify(data),
+    });
+    const _data = await response.json();
+    setToast({
+      ...toast,
+      toastMessage: POST_SUCCUSS,
+      toastStatus: true,
+      toastType: "success",
+    });
+    return _data;
+  } catch (err) {
+    console.log(err);
+    setToast({
+      ...toast,
+      toastMessage: POST_FAIL,
+      toastStatus: true,
+      toastType: "error",
+    });
+  }
+};
+
+const deleteResource = async (id, setToast, toast) => {
+  try {
+    const response = await fetch(`${END_POINT}/resources/deleteResource`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+      body: JSON.stringify({ resourceId: id }),
+    });
+
+    const data = await response.json();
+    setToast({
+      ...toast,
+      toastMessage: DELETE_SUCCESS,
+      toastStatus: true,
+      toastType: "success",
+    });
+    return data;
+  } catch (err) {
+    console.log(err);
+    setToast({
+      ...toast,
+      toastMessage: DELETE_FAIL,
+      toastStatus: true,
+      toastType: "error",
+    });
+  }
+};
+
+export { getResources, postResources, deleteResource };


### PR DESCRIPTION
## Issue that this pull request solves

[Issue Link](https://github.com/HITK-TECH-Community/Community-Website/issues/995) reslove #995 
 Closes: #995 

### Brief description of what is fixed or changed
Refactoring the Resources page and make all api's related to Resources in a one file.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes does not break the current system and it passes all the current test cases.
