### PR TITLE
[Refactor] Frontend API Calls should be kept under the Service folder for Faq Fixed

### DIFF
--- a/frontend/src/pages/Admin/Components/Faq/AddFaq/AddFaq.jsx
+++ b/frontend/src/pages/Admin/Components/Faq/AddFaq/AddFaq.jsx
@@ -2,19 +2,24 @@ import React, { useRef, useState } from "react";
 import styles from "./add-faq.module.scss";
 import { Button2 } from "../../../../../components/util/Button/index";
 import { SimpleToast } from "../../../../../components/util/Toast/Toast";
-import { END_POINT } from "../../../../../config/api";
+import { postFaq } from "../../../../../service/Faq"; 
 
 export function AddFaq() {
   const tagRef = useRef();
   const [tags, setTags] = useState([]);
   const [formData, setFormData] = useState({ question: "", answer: "", tags: [] });
   const [errorObj, setErrorObj] = useState({});
-  const [successToast, setSuccessToast] = useState(false);
-  const [errorToast, setErrorToast] = useState(false);
+  const [toast, setToast] = useState({
+    toastMessage: "",
+    toastStatus: false,
+    toastType: "success",
+  });
 
   const handleCloseToast = () => {
-    setSuccessToast(false);
-    setErrorToast(false);
+    setToast({
+      ...toast,
+      toastStatus: false,
+    });
   };
 
   const handleValidation = () => {
@@ -72,25 +77,10 @@ export function AddFaq() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (handleValidation()) {
-      try {
-        const response = await fetch(`${END_POINT}/faq/postFaq`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${localStorage.getItem("token")}`,
-          },
-          body: JSON.stringify(formData),
-        });
-
-        if (response.status === 200) {
-          setSuccessToast(true);
-          setFormData({ question: "", answer: "", tags: [] });
-          setTags([]);
-        } else {
-          setErrorToast(true);
-        }
-      } catch (error) {
-        setErrorToast(true);
+      const { success } = await postFaq(formData, setToast, toast);
+      if (success) {
+        setFormData({ question: "", answer: "", tags: [] });
+        setTags([]);
       }
     }
   };
@@ -193,16 +183,10 @@ export function AddFaq() {
         </div>
       </div>
       <SimpleToast
-        open={successToast}
-        message="FAQ has been added"
+        open={toast.toastStatus}
+        message={toast.toastMessage}
         handleCloseToast={handleCloseToast}
-        severity="success"
-      />
-      <SimpleToast
-        open={errorToast}
-        message="Database Error"
-        handleCloseToast={handleCloseToast}
-        severity="error"
+        severity={toast.toastType}
       />
     </div>
   );

--- a/frontend/src/pages/Admin/Components/Faq/Q&A/ManageQ&A/ManageQ&A.jsx
+++ b/frontend/src/pages/Admin/Components/Faq/Q&A/ManageQ&A/ManageQ&A.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { END_POINT } from "../../../../../../config/api";
 import style from "./manage.module.scss";
 import { makeStyles } from "@material-ui/core/styles";
 import Modal from "@material-ui/core/Modal";
@@ -8,6 +7,8 @@ import Typography from "@material-ui/core/Typography";
 import { AiOutlineArrowLeft } from "react-icons/ai";
 import { SimpleToast } from "../../../../../../components/util/Toast/Toast";
 import Loader from "../../../../../../components/util/Loader";
+import { getQuestionById, deleteAnswer, deleteQuestion, updateQuestionStatus, updateAnswerStatus, getAnswers } from "../../../../../../service/Faq";
+import { hideToast, showToast } from "../../../../../../service/toastService";
 
 const useStyles = makeStyles((theme) => ({
   modal: {
@@ -32,7 +33,7 @@ const useStyles = makeStyles((theme) => ({
 export function Manageqa({ setTab, qId }) {
   const [ans, setAns] = useState([]);
   const [qns, setQns] = useState();
-  const [toogle, setToogle] = useState(false);
+  const [toggle, setToggle] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
   const [toast, setToast] = useState({
     toastStatus: false,
@@ -42,29 +43,12 @@ export function Manageqa({ setTab, qId }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [questionToDelete, setQuestionToDelete] = useState(null);
   const classes = useStyles();
+
   const getQuestion = async (id) => {
     setIsLoaded(true);
-    try {
-      const qUrl = `${END_POINT}/question/getQuestionById/${id}`;
-      const qResponse = await fetch(qUrl);
-      const qRes = await qResponse.json();
-      setQns(qRes);
-      setToast({
-        ...toast,
-        toastMessage: "Successfully get Question",
-        toastStatus: true,
-        toastType: "success",
-      });
-    } catch (error) {
-      console.log(error);
-      setIsLoaded(false);
-      setToast({
-        ...toast,
-        toastMessage: "Check network failed to fetch",
-        toastStatus: true,
-        toastType: "error",
-      });
-    }
+    const qRes = await getQuestionById(id, setToast);
+    setQns(qRes);
+    setIsLoaded(false);
   };
 
   const handleOpenConfirmModal = (id) => {
@@ -77,290 +61,131 @@ export function Manageqa({ setTab, qId }) {
   };
 
   const handleDeleteAnswer = async (answerId) => {
-    try {
-      const url = `${END_POINT}/answers/deleteanswer`;
-      const response = await fetch(url, {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify({ answerId }),
-      });
-
-      const data = await response.json();
-      setToast({
-        ...toast,
-        toastMessage: "Successfully deleted answer",
-        toastStatus: true,
-        toastType: "success",
-      });
-      setToogle(!toogle);
-    } catch (error) {
-      console.log(error);
-      setToast({
-        ...toast,
-        toastMessage: "Unable to delete answer",
-        toastStatus: true,
-        toastType: "error",
-      });
-    }
+    await deleteAnswer(answerId, setToast);
+    setToggle(!toggle);
   };
 
   const handleDeleteQuestion = async () => {
-    try {
-      const url = `${END_POINT}/question/deletequestion`;
-      const response = await fetch(url, {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify({ questionId: questionToDelete }),
-      });
-
-      const data = await response.json();
-      setToast({
-        ...toast,
-        toastMessage: "Successfully deleted question",
-        toastStatus: true,
-        toastType: "success",
-      });
-      setTab(18);
-      setToogle(!toogle);
-    } catch (error) {
-      console.log(error);
-      setToast({
-        ...toast,
-        toastMessage: "Unable to delete question",
-        toastStatus: true,
-        toastType: "error",
-      });
-    }
+    await deleteQuestion(questionToDelete, setToast);
+    setConfirmDelete(false); 
+    setTab(18);
+    setToggle(!toggle);
   };
 
   const updateQuestion = async (id, status) => {
-    try {
-      const qUrl = `${END_POINT}/question/updateStatus`;
-      const qResponse = await fetch(qUrl, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify({ id: id, status: status }),
-      });
-      const qRes = await qResponse.json();
-      setToogle(!toogle);
-      setToast({
-        ...toast,
-        toastMessage: "Updated Successfully!",
-        toastStatus: true,
-        toastType: "success",
-      });
-    } catch (error) {
-      console.log(error);
-      setToast({
-        ...toast,
-        toastMessage: "Check network failed to update",
-        toastStatus: true,
-        toastType: "error",
-      });
-    }
+    await updateQuestionStatus(id, status, setToast);
+    setToggle(!toggle);
   };
 
   const getAnswer = async (questionId) => {
-    try {
-      const aUrl = `${END_POINT}/answers/${questionId}`;
-      const aResponse = await fetch(aUrl);
-      const aRes = await aResponse.json();
-      setAns(aRes.data);
-      setIsLoaded(false);
-      setToast({
-        ...toast,
-        toastMessage: "Successfully get answers",
-        toastStatus: true,
-        toastType: "success",
-      });
-    } catch (error) {
-      console.log(error);
-      setIsLoaded(false);
-      setToast({
-        ...toast,
-        toastMessage: "Check network failed to fetch",
-        toastStatus: true,
-        toastType: "error",
-      });
-    }
+    setIsLoaded(true);
+    const aRes = await getAnswers(questionId, setToast);
+    setAns(aRes);
+    setIsLoaded(false);
   };
 
   const updateAnswer = async (id, status) => {
-    try {
-      const aUrl = `${END_POINT}/answers/updateStatus`;
-      const aResponse = await fetch(aUrl, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify({ id: id, status: status }),
-      });
-      const aRes = await aResponse.json();
-      setToogle(!toogle);
-      setToast({
-        ...toast,
-        toastMessage: "Updated successfully",
-        toastStatus: true,
-        toastType: "success",
-      });
-    } catch (error) {
-      console.log(error);
-      setToast({
-        ...toast,
-        toastMessage: "Check network failed to Update",
-        toastStatus: true,
-        toastType: "error",
-      });
-    }
+    await updateAnswerStatus(id, status, setToast);
+    setToggle(!toggle);
   };
 
   const handleCloseToast = (event, reason) => {
     if (reason === "clickaway") {
       return;
     }
-    setToast({ ...toast, toastStatus: false });
+    hideToast(setToast);
   };
 
   useEffect(() => {
     getQuestion(qId);
     getAnswer(qId);
-  }, [toogle]);
+  }, [toggle]);
 
   return (
     <div>
       <h1 className={style["head"]}>Manage Q&A</h1>
-      <div className={style["back"]}>
+      <div className={style["back"]} style={{ cursor: "pointer" }}>
         <AiOutlineArrowLeft size={"35px"} onClick={() => setTab(18)} />
       </div>
-      <div className={style["data-loader"]}>{isLoaded ? <Loader /> : null}</div>
-      {isLoaded || (
+      <div className={style["data-loader"]}>{isLoaded && <Loader />}</div>
+      {!isLoaded && (
         <>
-        <h1 className={style["head"]}>Question</h1>
+          <h1 className={style["head"]}>Question</h1>
           <div className={style["question"]}>
-          <div className={style["card-item"]}>
-            <div className={style["card-info"]}>
-              <h1>{qns?.title}</h1>
-              <div className={style["questionBox"]}>
-                <h3 className={style["card-question"]}>{qns?.description}</h3>
-                <div className={style["button-group"]}>
-                  <button
-                    className={
-                      qns?.isApproved
-                        ? style["button-delete"]
-                        : style["button-approve"]
-                    }
-                    id={`${qns?._id}`}
-                    onClick={(e) => {
-                      updateQuestion(e.currentTarget.id, !qns?.isApproved);
-                    }}
-                  >
-                    {qns?.isApproved ? "Reject" : "Approve"}
-                  </button>
-                  <button
-                    name={`${qns?._id}`}
-                    onClick={(e) =>
-                      handleOpenConfirmModal(e.currentTarget.name)
-                    }
-                    className={style["button-delete"]}
-                  >
-                    Delete
-                  </button>
-                </div>
-                <div style={{ display: "flex", padding: "10px 30px 10px 30px" }}>
-                {qns?.tags?.map((tag) => (
-                  <p className={style["tags"]}>{tag}</p>
-                ))}
-              </div>
-              </div>
-              
-            </div>
-          </div>
-          </div>
-          <h1 className={style["head"]}>Answers</h1>
-
-          {ans?.length === 0 ? (
-            <span>No answers Found</span>
-          ) : (
-            <div className={ans?.length==1?style["question"]:style["answer"]}>
-              {ans?.map((a) => (
-              <div className={style["card-item"]}>
-                <div className={style["card-info"]}>
-                  <div className={style["answerBox"]}>
-                    <h3 className={style["card-answer"]}>{a.answer}</h3>
-                    <div className={style["button-group"]}>
-                      <button
-                        className={
-                          a?.isApproved
-                            ? style["button-delete"]
-                            : style["button-approve"]
-                        }
-                        id={`${a?._id}`}
-                        onClick={(e) => {
-                          updateAnswer(e.currentTarget.id, !a?.isApproved);
-                        }}
-                      >
-                        {a?.isApproved ? "Reject" : "Approve"}
-                      </button>
-                      <button
-                        name={`${a?._id}`}
-                        onClick={(e) =>
-                          handleDeleteAnswer(e.currentTarget.name)
-                        }
-                        className={style["button-delete"]}
-                      >
-                        Delete
-                      </button>
-                    </div>
+            <div className={style["card-item"]}>
+              <div className={style["card-info"]}>
+                <h1>{qns?.title}</h1>
+                <div className={style["questionBox"]}>
+                  <h3 className={style["card-question"]}>{qns?.description}</h3>
+                  <div className={style["button-group"]}>
+                    <button
+                      className={qns?.isApproved ? style["button-delete"] : style["button-approve"]}
+                      id={`${qns?._id}`}
+                      onClick={(e) => updateQuestion(e.currentTarget.id, !qns?.isApproved)}
+                    >
+                      {qns?.isApproved ? "Reject" : "Approve"}
+                    </button>
+                    <button
+                      name={`${qns?._id}`}
+                      onClick={(e) => handleOpenConfirmModal(e.currentTarget.name)}
+                      className={style["button-delete"]}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                  <div style={{ display: "flex", padding: "10px 30px 10px 30px" }}>
+                    {qns?.tags?.map((tag) => (
+                      <p className={style["tags"]} key={tag}>{tag}</p>
+                    ))}
                   </div>
                 </div>
               </div>
-              ))}
-            </div>
-          )}
-        </>
-      )}
-      {
-        <Modal
-          open={confirmDelete}
-          onClose={handleCloseConfirmModal}
-          className={classes.modal}
-        >
-          <div className={classes.paper}>
-            <Typography variant="h6" component="h2">
-              Confirm Delete
-            </Typography>
-            <Typography sx={{ mt: 2 }}>
-              Are you sure you want to delete this question and all its answers?
-            </Typography>
-            <div className={classes.buttons}>
-              <Button
-                onClick={handleDeleteQuestion}
-                variant="contained"
-                color="secondary"
-              >
-                Confirm
-              </Button>
-              <Button
-                onClick={handleCloseConfirmModal}
-                variant="contained"
-                color="primary"
-              >
-                Cancel
-              </Button>
             </div>
           </div>
-        </Modal>
-      }
+        </>
+      )}
+      <h1 className={style["head"]}>Answers</h1>
+      {ans?.length === 0 ? (
+        <span>No answers Found</span>
+      ) : (
+        <div className={ans?.length === 1 ? style["question"] : style["answer"]}>
+          {ans?.map((a) => (
+            <div className={style["card-item"]} key={a?._id}>
+              <div className={style["card-info"]}>
+                <div className={style["answerBox"]}>
+                  <h3 className={style["card-answer"]}>{a.answer}</h3>
+                  <div className={style["button-group"]}>
+                    <button
+                      className={a?.isApproved ? style["button-delete"] : style["button-approve"]}
+                      id={`${a?._id}`}
+                      onClick={(e) => updateAnswer(e.currentTarget.id, !a?.isApproved)}
+                    >
+                      {a?.isApproved ? "Reject" : "Approve"}
+                    </button>
+                    <button
+                      name={`${a?._id}`}
+                      onClick={(e) => handleDeleteAnswer(e.currentTarget.name)}
+                      className={style["button-delete"]}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <Modal open={confirmDelete} onClose={handleCloseConfirmModal} className={classes.modal}>
+        <div className={classes.paper}>
+          <Typography variant="h6" component="h2">Confirm Delete</Typography>
+          <Typography sx={{ mt: 2 }}>Are you sure you want to delete this question and all its answers?</Typography>
+          <div className={classes.buttons}>
+            <Button onClick={handleDeleteQuestion} variant="contained" color="secondary">Confirm</Button>
+            <Button onClick={handleCloseConfirmModal} variant="contained" color="primary">Cancel</Button>
+          </div>
+        </div>
+      </Modal>
       {toast.toastStatus && (
         <SimpleToast
           open={toast.toastStatus}

--- a/frontend/src/pages/Admin/Components/Faq/Q&A/QandA.jsx
+++ b/frontend/src/pages/Admin/Components/Faq/Q&A/QandA.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import style from "./qanda.module.scss";
-import { END_POINT } from "../../../../../config/api";
+import { getAllQuestions } from "../../../../../service/Faq";
 import { SimpleToast } from "../../../../../components/util/Toast/Toast";
 import Loader from "../../../../../components/util/Loader";
+import { hideToast } from "../../../../../service/toastService";
 
 export function QandA({ setTab, setQId, tab }) {
   const [cards, setCards] = useState([]);
@@ -12,34 +13,25 @@ export function QandA({ setTab, setQId, tab }) {
     toastType: "",
     toastMessage: "",
   });
+
   const getdata = async () => {
-    setIsLoaded(true)
-    try {
-      const url = `${END_POINT}/question/getallquestions`;
-      const response = await fetch(url);
-      const res = await response.json();
-      setCards(res);
-    } catch (error) {
-      console.log(error);
-      setToast({
-        ...toast,
-        toastMessage: "Check network failed to fetch",
-        toastStatus: true,
-        toastType: "error",
-      });
-      
-    }
-    setIsLoaded(false)
+    setIsLoaded(true);
+    const data = await getAllQuestions(setToast, toast);
+    setCards(data);
+    setIsLoaded(false);
   };
+
   const handleCloseToast = (event, reason) => {
     if (reason === "clickaway") {
       return;
     }
-    setToast({ ...toast, toastStatus: false });
+    hideToast(setToast);
   };
+
   useEffect(() => {
     getdata();
   }, [tab]);
+
   return (
     <div>
       <h1 className={style["head"]}>Manage Q&A</h1>

--- a/frontend/src/pages/Faq/Faq.jsx
+++ b/frontend/src/pages/Faq/Faq.jsx
@@ -6,7 +6,7 @@ import AccordionSummary from "@material-ui/core/AccordionSummary";
 import Typography from "@material-ui/core/Typography";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import style from "./faq.module.scss";
-import { END_POINT } from "../../config/api";
+import { getFaq } from "../../service/Faq";
 import { SimpleToast } from "../../components/util/Toast";
 import Loader from "../../components/util/Loader";
 
@@ -55,31 +55,16 @@ export function Faq(props) {
     setError(false);
   };
 
-  const fetchFaqs = () => {
-    fetch(`${END_POINT}/faq/getFaq`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    })
-      .then((response) =>
-        response.json().then((res) => {
-          if (response.status === 200) {
-            setFaqs(res.Faq);
-            setIsFetching(false);
-          } else {
-            setFaqs([]);
-            setIsFetching(false);
-            setError(true);
-          }
-        })
-      )
-      .catch((err) => {
-        setFaqs([]);
-        setIsFetching(false);
-        setError(true);
-        console.error("Unexpected Error occured: ", err);
-      });
+  const fetchFaqs = async () => {
+    try {
+      const faqs = await getFaq();
+      setFaqs(faqs);
+      setIsFetching(false);
+    } catch (error) {
+      setFaqs([]);
+      setError(true);
+      setIsFetching(false);
+    }
   };
 
   useEffect(() => {

--- a/frontend/src/service/Faq.jsx
+++ b/frontend/src/service/Faq.jsx
@@ -1,0 +1,326 @@
+import { END_POINT } from "../config/api";
+import { showToast } from "./toastService";
+
+export async function postFaq(formData, setToast, toast) {
+    try {
+      const response = await fetch(`${END_POINT}/faq/postFaq`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+        body: JSON.stringify(formData),
+      });
+  
+      if (response.ok) {
+        setToast({
+          ...toast,
+          toastMessage: "FAQ has been added",
+          toastStatus: true,
+          toastType: "success",
+        });
+        return { success: true };
+      } else {
+        setToast({
+          ...toast,
+          toastMessage: "Database Error",
+          toastStatus: true,
+          toastType: "error",
+        });
+        return { success: false, error: "Database Error" };
+      }
+    } catch (error) {
+      setToast({
+        ...toast,
+        toastMessage: "Network Error",
+        toastStatus: true,
+        toastType: "error",
+      });
+      return { success: false, error: "Network Error" };
+    }
+  }
+
+export async function getFaq() {
+    try {
+      const response = await fetch(`${END_POINT}/faq/getFaq`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch FAQs");
+      }
+      const data = await response.json();
+      return data.Faq;
+    } catch (error) {
+      console.error("Failed to fetch FAQs:", error.message);
+      throw new Error("Failed to fetch FAQs");
+    }
+}
+
+export const deleteFaq  = async (faqId, setToast, toast) => {
+    const url = `${END_POINT}/faq/deleteFaq`;
+    const body = { faqId: faqId };
+    const headers = {
+      "Content-Type": "application/json",
+      authorization: `Bearer ${localStorage.getItem("token")}`,
+    };
+    try {
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: headers,
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+      setToast({
+        ...toast,
+        toastMessage: data.message,
+        toastStatus: true,
+        toastType: "success",
+      });
+      return data.message;
+    } catch (error) {
+      console.error("Failed to delete FAQ:", error.message);
+      setToast({
+        ...toast,
+        toastMessage: "Failed to delete FAQ",
+        toastStatus: true,
+        toastType: "error",
+      });
+      throw new Error("Failed to delete FAQ");
+    }
+};
+
+export const updateFaq = async (faqId, updatedFaqDetails, setToast, toast) => {
+    try {
+        const response = await fetch(`${END_POINT}/faq/updateFaq`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                authorization: `Bearer ${localStorage.getItem("token")}`,
+            },
+            body: JSON.stringify({ faqId, ...updatedFaqDetails }),
+        });
+
+        if (!response.ok) {
+            throw new Error("Failed to update FAQ");
+        }
+
+        const data = await response.json();
+        setToast({
+            ...toast,
+            toastMessage: data.message,
+            toastStatus: true,
+            toastType: "success",
+        });
+        return data.message;
+    } catch (error) {
+        console.error("Failed to update FAQ:", error.message);
+        setToast({
+            ...toast,
+            toastMessage: "Failed to update FAQ",
+            toastStatus: true,
+            toastType: "error",
+        });
+        throw new Error("Failed to update FAQ");
+    }
+};
+
+export const getAllQuestions = async (setToast, toast) => {
+  try {
+    const response = await fetch(`${END_POINT}/question/getallquestions`);
+    if (!response.ok) {
+      throw new Error("Failed to fetch questions");
+    }
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch questions:", error.message);
+    showToast(setToast, "Check network failed to fetch", "error");
+    return [];
+  }
+};
+
+export async function getQuestionById(id, setToast) {
+  const qUrl = `${END_POINT}/question/getQuestionById/${id}`;
+  try {
+    const qResponse = await fetch(qUrl);
+    const qRes = await qResponse.json();
+    return qRes;
+  } catch (error) {
+    console.log(error);
+    showToast(setToast, "Failed to fetch question", "error");
+    throw new Error("Failed to fetch question");
+  }
+}
+
+export async function deleteAnswer(answerId, setToast) {
+  const url = `${END_POINT}/answers/deleteanswer`;
+  try {
+    const response = await fetch(url, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+      body: JSON.stringify({ answerId }),
+    });
+    const data = await response.json();
+    showToast(setToast, "Successfully deleted answer");
+    return data;
+  } catch (error) {
+    console.log(error);
+    showToast(setToast, "Failed to delete answer", "error");
+    throw new Error("Failed to delete answer");
+  }
+}
+
+export async function deleteQuestion(questionId, setToast) {
+  const url = `${END_POINT}/question/deletequestion`;
+  try {
+    const response = await fetch(url, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+      body: JSON.stringify({ questionId }),
+    });
+    const data = await response.json();
+    showToast(setToast, "Successfully deleted question");
+    return data;
+  } catch (error) {
+    console.log(error);
+    showToast(setToast, "Failed to delete question", "error");
+    throw new Error("Failed to delete question");
+  }
+}
+
+export async function updateQuestionStatus(id, status, setToast) {
+  const qUrl = `${END_POINT}/question/updateStatus`;
+  try {
+    const qResponse = await fetch(qUrl, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+      body: JSON.stringify({ id, status }),
+    });
+    const qRes = await qResponse.json();
+    showToast(setToast, "Question status updated successfully");
+    return qRes;
+  } catch (error) {
+    console.log(error);
+    showToast(setToast, "Failed to update question status", "error");
+    throw new Error("Failed to update question status");
+  }
+}
+
+export async function updateAnswerStatus(id, status, setToast) {
+  const aUrl = `${END_POINT}/answers/updateStatus`;
+  try {
+    const aResponse = await fetch(aUrl, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+      body: JSON.stringify({ id, status }),
+    });
+    const aRes = await aResponse.json();
+    showToast(setToast, "Answer status updated successfully");
+    return aRes;
+  } catch (error) {
+    console.log(error);
+    showToast(setToast, "Failed to update answer status", "error");
+    throw new Error("Failed to update answer status");
+  }
+}
+
+export async function getAnswers(questionId, setToast) {
+  const aUrl = `${END_POINT}/answers/${questionId}`;
+  try {
+    const aResponse = await fetch(aUrl);
+    const aRes = await aResponse.json();
+    return aRes.data;
+  } catch (error) {
+    console.log(error);
+    showToast(setToast, "Failed to fetch answers", "error");
+    throw new Error("Failed to fetch answers");
+  }
+}
+
+export const getAllQuestion = async (handleToast) => {
+  try {
+    const response = await fetch(`${END_POINT}/question/getallquestions`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    showToast(handleToast, "Failed to fetch questions", "error");
+    throw new Error("Failed to fetch questions");
+  }
+};
+
+export const uploadData = async (formData, handleToast) => {
+  try {
+    const url = `${END_POINT}/question`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(formData),
+    });
+    const data = await response.json();
+    showToast(handleToast, "Q&A added successfully");
+    return data;
+  } catch (error) {
+    showToast(handleToast, "Failed to add Q&A", "error");
+    throw new Error("Failed to add Q&A");
+  }
+};
+
+export const upvote = async (questionId, handleToast) => {
+  try {
+    const response = await fetch(`${END_POINT}/question/upvote`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ questionId }),
+    });
+    if (!response.ok) {
+      throw new Error("Failed to upvote question");
+    }
+    showToast(handleToast, "Upvote Successfully");
+    return response.json();
+  } catch (error) {
+    showToast(handleToast, "Failed to upvote question", "error");
+    throw new Error("Failed to upvote question");
+  }
+};
+
+export const downvote = async (questionId, handleToast) => {
+  try {
+    const response = await fetch(`${END_POINT}/question/downvote`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ questionId }),
+    });
+    if (!response.ok) {
+      throw new Error("Failed to downvote question");
+    }
+    showToast(handleToast, "Downvote Successfully");
+    return response.json();
+  } catch (error) {
+    showToast(handleToast, "Failed to downvote question", "error");
+    throw new Error("Failed to downvote question");
+  }
+};

--- a/frontend/src/service/toastService.jsx
+++ b/frontend/src/service/toastService.jsx
@@ -1,0 +1,16 @@
+
+export const showToast = (setToast, message, type = "success") => {
+    setToast({
+      toastStatus: true,
+      toastType: type,
+      toastMessage: message,
+    });
+  };
+  
+export const hideToast = (setToast) => {
+    setToast({
+        toastStatus: false,
+        toastType: "",
+        toastMessage: "",
+    });
+};


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #985 

### Brief description of what is fixed or changed
1. add toastService to service folder
2. Refactoring the FAQ folder and making all API's related to about in one file.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.
