### PR TITLE
fix(Q&A): input fields getting cleared and autoclosing the box pop after submission

### DIFF
--- a/frontend/src/pages/Q&A/Q&A.jsx
+++ b/frontend/src/pages/Q&A/Q&A.jsx
@@ -5,7 +5,12 @@ import "./Ques.scss";
 import Joi from "joi-browser";
 import Loader from "../../components/util/Loader/index";
 import { SimpleToast } from "../../components/util/Toast";
-import { getAllQuestion, uploadData, upvote, downvote } from "../../service/Faq";
+import {
+  getAllQuestion,
+  uploadData,
+  upvote,
+  downvote,
+} from "../../service/Faq";
 import { showToast, hideToast } from "../../service/toastService";
 
 function Ques(props) {
@@ -109,6 +114,7 @@ function Ques(props) {
           });
           setFormErrors({});
           setCheckedState(new Array(Tags.length).fill(false));
+          setButtonPressed(false);
         })
         .catch(() => {
           setIsUploadingData(false);
@@ -129,7 +135,7 @@ function Ques(props) {
     await upvote(questionId, setToast);
     fetchQuestions();
   };
-  
+
   const handleDownvote = async (questionId) => {
     await downvote(questionId, setToast);
     fetchQuestions();
@@ -164,7 +170,10 @@ function Ques(props) {
                   <p>Created At {new Date(item.createdAt).toLocaleString()}</p>
                 </div>
                 <div>
-                  <button className="vote-btn" onClick={() => handleUpvote(item._id)}>
+                  <button
+                    className="vote-btn"
+                    onClick={() => handleUpvote(item._id)}
+                  >
                     👍{item.upvotes}
                   </button>
                   <button
@@ -197,7 +206,10 @@ function Ques(props) {
           }
         >
           <form className="question_form" onSubmit={handleSubmit}>
-            <button className="close-popup" onClick={() => setButtonPressed(false)}>
+            <button
+              className="close-popup"
+              onClick={() => setButtonPressed(false)}
+            >
               X
             </button>
             <h3
@@ -228,7 +240,9 @@ function Ques(props) {
                       onChange={handleChange}
                     />
                     <i className="fas fa-heading"></i>
-                    <div className={`${style["validation"]} validation d-sm-none d-md-block`}>
+                    <div
+                      className={`${style["validation"]} validation d-sm-none d-md-block`}
+                    >
                       {formerrors["title"] ? (
                         <div>* {formerrors["title"]}</div>
                       ) : (
@@ -254,8 +268,13 @@ function Ques(props) {
                       value={formdata.description}
                       onChange={handleChange}
                     />
-                    <i className="fas fa-envelope" style={{ marginTop: 27 }}></i>
-                    <div className={`${style["validation"]} validation d-sm-none d-md-block`}>
+                    <i
+                      className="fas fa-envelope"
+                      style={{ marginTop: 27 }}
+                    ></i>
+                    <div
+                      className={`${style["validation"]} validation d-sm-none d-md-block`}
+                    >
                       {formerrors["body"] ? (
                         <div>* {formerrors["body"]}</div>
                       ) : (
@@ -322,7 +341,10 @@ function Ques(props) {
                 </div>
               </div>
 
-              <div className={style["submit-btn"]} style={{ justifyContent: "space-around", marginBottom: "1rem" }}>
+              <div
+                className={style["submit-btn"]}
+                style={{ justifyContent: "space-around", marginBottom: "1rem" }}
+              >
                 <div className="data-loader">
                   {isUploadingData ? (
                     <Loader />


### PR DESCRIPTION
fixed the input getting cleared if input failed the validation

fixes #977

## Issue that this pull request solves

 Closes: #977 

## Proposed changes

- fixed the issue of input fields getting cleared in QandA page ( ask your question fields ) if input is not matching the validation criteria 

- previously reseting of input field code was written outside the both condition whether error occur or not due to which if any condition happen reset code used to run and input get cleared 

- i modified the code that reset condition will work only when  validation is matched and q&a is submitted successfully otherwise it will not reset the input field 

- also question box pop will be closed automatically after the successfull submission 

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

https://github.com/HITK-TECH-Community/Community-Website/assets/127100604/e5415a09-219c-4fb7-bcfa-489e7f362af0



