### PR TITLE
There should be 2 more buttons on manage broadcasts card Added

### DIFF
--- a/backend/app/routes/broadcast/@validationSchema/index.js
+++ b/backend/app/routes/broadcast/@validationSchema/index.js
@@ -19,6 +19,7 @@ const updateBroadcastValidationSchema = Joi.object().keys({
     .min(new Date(new Date() - 100000)),
   imageUrl: Joi.array().min(1).items(Joi.string().uri()),
   tags: Joi.array().min(1).items(Joi.string()),
+  isApproved: Joi.boolean().required(),
   id : Joi.string().min(24).max(24).required()
 });
 

--- a/frontend/src/pages/Admin/Components/Broadcast/Broadcast.jsx
+++ b/frontend/src/pages/Admin/Components/Broadcast/Broadcast.jsx
@@ -37,12 +37,12 @@ export function Broadcast(props) {
               <AiFillEdit className={style["editt"]} />
             </div>
             <div className={style["card-content"]}>
-              <Link
+              <div
                 onClick={() => props.setTab(16)}
                 className={style["main-btn"]}
               >
                 Manage here
-              </Link>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Admin/Components/Broadcast/ManageBroadcasts/Card/Card.jsx
+++ b/frontend/src/pages/Admin/Components/Broadcast/ManageBroadcasts/Card/Card.jsx
@@ -6,7 +6,10 @@ import { IconButton } from "@material-ui/core";
 import { useSelector } from "react-redux";
 import { SimpleToast } from "../../../../../../components/util/Toast";
 import style from "./card.module.scss";
-import { deleteBoardcast } from "../../../../../../service/Broadcast.jsx";
+import {
+  UpdateBoardCast,
+  deleteBoardcast,
+} from "../../../../../../service/Broadcast.jsx";
 
 export function Card(props) {
   let dark = props.theme;
@@ -38,13 +41,30 @@ export function Card(props) {
     }
     setToast({ ...toast, toastStatus: false });
   };
-
   async function deleteCard(id) {
     const res = await deleteBoardcast(id, setToast, toast);
-      if (res) {
-        props.setHandleDelete(props.handleDelete + 1);
-      }
+    if (res) {
+      props.setHandleDelete(props.handleDelete + 1);
+    }
   }
+
+  const handleApprove = async () => {
+    const { project } = props;
+    const data = {
+      id: project._id,
+      content: project.content,
+      link: project.link,
+      expiresOn: project.expiresOn,
+      imageUrl: project.imageUrl,
+      tags: project.tags,
+      isApproved: true,
+      title: project.title,
+    };
+    const res = await UpdateBoardCast(data, setToast, toast);
+    if (res) {
+      props.setHandleDelete(props.handleDelete + 1);
+    }
+  };
 
   const isSuperAdmin = useSelector((state) => state.isSuperAdmin);
   const date = new Date(props.project.createdAt.slice(0, 10));
@@ -137,6 +157,24 @@ export function Card(props) {
             >
               View Details
             </button>
+            <div className={style["button-group"]}>
+              <button
+                className={
+                  !props?.project?.isApproved
+                    ? style["button-approve"]
+                    : style["button-info"]
+                }
+                onClick={!props?.project?.isApproved && handleApprove}
+              >
+                {props?.project?.isApproved ? "Approved" : "Approve"}
+              </button>
+              <button
+                className={style["button-delete"]}
+                onClick={() => deleteCard(props.id)}
+              >
+                Reject
+              </button>
+            </div>
           </div>
         </div>
       </ReactCardFlip>

--- a/frontend/src/pages/Admin/Components/Broadcast/ManageBroadcasts/Card/card.module.scss
+++ b/frontend/src/pages/Admin/Components/Broadcast/ManageBroadcasts/Card/card.module.scss
@@ -14,6 +14,66 @@
   box-shadow: 0.5em 0.5em 0.5em rgb(54, 53, 53);
 }
 
+.button-group {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin: 5px 2px 5px 2px;
+}
+
+.button-approve {
+  padding: 10px;
+  border: none;
+  outline: none;
+  border-radius: 5px;
+  background-color: rgb(6, 158, 41);
+  margin: 5px;
+  color: #fff;
+  width: 120px;
+  font-size: medium;
+  font-weight: bold;
+  transition: background-color 200ms;
+}
+
+.button-edit:hover {
+  background-color: rgb(10, 205, 53);
+}
+
+.button-info {
+  padding: 10px;
+  border: none;
+  outline: none;
+  border-radius: 5px;
+  background-color: rgb(4, 123, 182);
+  margin: 5px;
+  color: #fff;
+  width: 120px;
+  font-size: medium;
+  font-weight: bold;
+  transition: background-color 200ms;
+}
+
+.button-delete {
+  padding: 10px;
+  border: none;
+  outline: none;
+  border-radius: 5px;
+  background-color: #fc0254;
+  margin: 5px;
+  color: #fff;
+  width: 120px;
+  font-size: medium;
+  font-weight: bold;
+  transition: background-color 200ms;
+  text-align: center;
+}
+
+.button-delete:hover {
+  background-color: #fc3779;
+}
+
 // for dark theme
 .card-item-dark {
   background-color: #171717;
@@ -28,7 +88,7 @@
   align-items: center;
   padding: 1.5em;
   color: var(--bs-light);
-  height: 380px;
+  height: 410px;
 }
 
 .clickable-card:hover {

--- a/frontend/src/service/Broadcast.jsx
+++ b/frontend/src/service/Broadcast.jsx
@@ -108,4 +108,41 @@ const postBoardcast = async ( data, setToast, toast) => {
   }
 };
 
-export { boardcast, customBoardcast, deleteBoardcast, postBoardcast };
+const UpdateBoardCast = async (data, setToast, toast) => {
+  try {
+    const response = await fetch(`${END_POINT}/broadcast/update`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        authorization: `Bearer ${localStorage.getItem("token")}`,
+      },
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      throw new Error("Failed to Approve");
+    }
+    setToast({
+      ...toast,
+      toastMessage: "Successfully Approved",
+      toastStatus: true,
+      toastType: "success",
+    });
+    return true;
+  } catch (error) {
+    console.log("Failed to Approve", error.message);
+    setToast({
+      ...toast,
+      toastMessage: "Failed to Approve",
+      toastStatus: true,
+      toastType: "error",
+    });
+  }
+};
+
+export {
+  boardcast,
+  customBoardcast,
+  deleteBoardcast,
+  postBoardcast,
+  UpdateBoardCast,
+};


### PR DESCRIPTION
## Issue that this pull request solves

[Issue Link](https://github.com/HITK-TECH-Community/Community-Website/issues/1015) resolve #1015 
 Closes: #1015 

### Brief description of what is fixed or changed
There should be 2 more buttons on manage broadcasts card - `approve` and `reject`. If a broadcast gets rejected, it is getting deleted from the db.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes does not break the current system and it passes all the current test cases.
