### PR TITLE
added functionality of sending mail when new user is created and when…

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,4 +1,5 @@
 MONGO_DB_URL=<mongoDB_URL>
+
 JWT_SECRET_KEY=<JWT_sceret>
 JWT_EXPIRES_IN=6h
 BASE_URL=https://community-website-backend.herokuapp.com
@@ -8,3 +9,7 @@ EMAIL_HOST=smtp.gmail.com
 CLUSTER=no
 JWT_RESET_PASSWORD_EXPIRES_IN=1h
 LOCAL_DEV_ENV=http://localhost:3500/
+
+
+EMAIL_PASS_FOR_NODEMAILER=<enter your gmail pass key>
+EMAIL_ID_FOR_SENDING_MAIL=<enter mail id from which you have to send mail to user>

--- a/backend/app/models/Subscriber.js
+++ b/backend/app/models/Subscriber.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const SubscriberSchema = new Schema(
+    {
+        firstName: {
+            type: String,
+            trim: true,
+        },
+        lastName: {
+            type: String,
+            trim: true,
+        },
+        email: {
+            type: String,
+            trim: true,
+            unique: true,
+        },
+    },
+    { timestamps: { createdAt: 'createdAt', updatedAt: 'updatedAt' } }
+);
+
+module.exports = mongoose.model('Subscriber', SubscriberSchema);

--- a/backend/app/routes/Subscriber/@validationSchema/index.js
+++ b/backend/app/routes/Subscriber/@validationSchema/index.js
@@ -1,0 +1,9 @@
+const Joi = require('joi');
+
+const SubscriberValidationSchema = Joi.object().keys({
+    firstName: Joi.string().trim().required(),
+    lastName: Joi.string().trim().required(),
+    email: Joi.string().trim().email().required(),
+});
+
+module.exports = SubscriberValidationSchema;

--- a/backend/app/routes/Subscriber/index.js
+++ b/backend/app/routes/Subscriber/index.js
@@ -1,0 +1,8 @@
+const router = require('express').Router({ mergeParams: true });
+const SubscriberValidationSchema = require('./@validationSchema');
+const validation = require('../../../helpers/middlewares/validation');
+const postSubscriber = require('./post');
+
+router.post('/', validation(SubscriberValidationSchema), postSubscriber);
+
+module.exports = router;

--- a/backend/app/routes/Subscriber/post.js
+++ b/backend/app/routes/Subscriber/post.js
@@ -1,0 +1,61 @@
+const to = require('await-to-js').default;
+const { ErrorHandler } = require('../../../helpers/error');
+const constants = require('../../../constants');
+const Subscriber = require('../../models/Subscriber');
+const {SendEmailUsingNodeMailer} = require('../../../utility/sendEmail');
+const {NewSubscriberMailTemplate} = require('../../../utility/emailTemplates');
+
+module.exports = async (req, res, next) => {
+
+    const [findErr, existingSubscriber] = await to(Subscriber.findOne({ email: req.body.email }));
+
+    if(findErr) {
+        const error = new ErrorHandler(constants.ERRORS.DATABASE, {
+            statusCode: 500,
+            message: 'Database Error',
+            errStack: findErr,
+        });
+        return next(error);
+    }
+
+    if(existingSubscriber) {
+        const error = new ErrorHandler(constants.ERRORS.SUBSCRIBER_EXISTS, {
+            statusCode: 409,
+            message: 'Subscriber already exists',
+        });
+        return next(error);
+    }
+
+    const [createErr] = await to(Subscriber.create({ ...req.body }));
+    if(createErr){
+        const error = new ErrorHandler(constants.ERRORS.DATABASE, {
+            statusCode: 500,
+            message: 'Database Error',
+            errStack: createErr,
+        });
+        return next(error);
+    }
+
+    // sending email to newly added user using nodemailer
+    try{
+        await SendEmailUsingNodeMailer(
+            req.body.email,
+            'Welcome to HITE-TECH Community',
+            NewSubscriberMailTemplate(req.body.firstName),
+        );
+    }
+    catch(error){
+        const e = new ErrorHandler(constants.ERRORS.EMAIL, {
+            statusCode: 500,
+            message: 'NodeMailer Error',
+            errStack: error,
+        });
+        return next(e);
+    }
+
+    res.status(200).send({
+        message: 'New Subscriber has been added successfully',
+    });
+
+    return next();
+}

--- a/backend/app/routes/broadcast/postBroadcast.js
+++ b/backend/app/routes/broadcast/postBroadcast.js
@@ -1,7 +1,10 @@
 const to = require('await-to-js').default;
 const Broadcast = require('../../models/Broadcast');
+const Subscriber = require('../../models/Subscriber');
 const { ErrorHandler } = require('../../../helpers/error');
 const constants = require('../../../constants');
+const { SendEmailUsingNodeMailer } = require('../../../utility/sendEmail');
+const { NewBroadCastMailTemplate } = require('../../../utility/emailTemplates');
 
 module.exports = async (req, res, next) => {
   const [err, { _id }] = await to(Broadcast.create({ ...req.body }));
@@ -13,6 +16,35 @@ module.exports = async (req, res, next) => {
     });
     return next(error);
   }
+
+  const [err1, SubscriberList] = await to(Subscriber.find());
+  if(err1){
+    const error = new ErrorHandler(constants.ERRORS.DATABASE, {
+      statusCode: 500,
+      message: 'Mongo Error: can not fetch subscriber list',
+      errStack: err,
+    });
+    return next(error);
+  }
+
+  try{
+    SubscriberList.map(async (subscriber) => {
+      await SendEmailUsingNodeMailer(
+        subscriber.email,
+        'New BroadCast Added',
+        NewBroadCastMailTemplate(subscriber),
+      )
+    })
+  }
+  catch(error){
+    const e = new ErrorHandler(constants.ERRORS.EMAIL, {
+      statusCode: 500,
+      message: 'NodeMailer Error',
+      errStack: error,
+    });
+    return next(e);
+  }
+
   res.status(200).send({
     message: 'Broadcast added successfully',
     id: _id,

--- a/backend/app/routes/contactUs/post.js
+++ b/backend/app/routes/contactUs/post.js
@@ -3,7 +3,7 @@ const { ErrorHandler } = require('../../../helpers/error');
 const constants = require('../../../constants');
 const contactUs = require('../../models/contactUs');
 const Admin = require('../../models/Admin');
-const sendEmail = require('../../../utility/sendEmail');
+const {sendEmail} = require('../../../utility/sendEmail');
 const { ContactUsMailTemplate } = require('../../../utility/emailTemplates');
 
 module.exports = async (req, res, next) => {

--- a/backend/app/routes/index.js
+++ b/backend/app/routes/index.js
@@ -11,6 +11,7 @@ const question = require('./Q&A/question');
 const answer = require('./Q&A/answers');
 const teamMember = require('./teamMember');
 const resource = require('./resources');
+const subscriber = require('./Subscriber');
 
 router.use('/admin', admin);
 router.use('/auth', auth);
@@ -24,4 +25,5 @@ router.use('/joinUs', joinUs);
 router.use('/teamMember', teamMember);
 router.use('/', tinyURL);
 router.use('/resources', resource);
+router.use('/subscribers', subscriber);
 module.exports = router;

--- a/backend/constants/constants.json
+++ b/backend/constants/constants.json
@@ -6,7 +6,8 @@
     "CRITICAL": "Critical Error",
     "WARNING": "Warning",
     "USER": "User ",
-    "UNEXPECTED": "Unexpected Error"
+    "UNEXPECTED": "Unexpected Error",
+    "SUBSCRIBER_EXISTS": "Subscriber already exists"
   },
   "PAGINATION_LIMIT": {
     "GET_ADMINS": 3,

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,7 +42,7 @@
     "multer": "^1.4.4",
     "nanoid": "^3.1.20",
     "node-cron": "^3.0.0",
-    "nodemailer": "^6.5.0",
+    "nodemailer": "^6.9.13",
     "response-time": "^2.3.2",
     "url-exists": "^1.0.3"
   },

--- a/backend/utility/emailTemplates.js
+++ b/backend/utility/emailTemplates.js
@@ -94,3 +94,190 @@ module.exports.ResourceDeletedMailTemplate = (adminName) => {
   `;
   return emailContent;
 };
+
+module.exports.NewSubscriberMailTemplate = (SubscriberName) => {
+  const emailContent = `
+  <!DOCTYPE html>
+  <html lang="en">
+  <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Welcome to HITK Tech Community</title>
+      <style>
+          body {
+              font-family: Arial, sans-serif;
+              margin: 0;
+              padding: 0;
+              background-color: #f6f6f6;
+          }
+          .container {
+              width: 100%;
+              padding: 20px;
+              background-color: #ffffff;
+              margin: 0 auto;
+              max-width: 600px;
+              box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+          }
+          .header {
+              text-align: center;
+              background-color: #007bff;
+              color: #ffffff;
+              padding: 10px 0;
+          }
+          .header h1 {
+              margin: 0;
+              font-size: 24px;
+          }
+          .content {
+              padding: 20px;
+          }
+          .content h2 {
+              font-size: 20px;
+              color: #333333;
+          }
+          .content p {
+              font-size: 16px;
+              color: #666666;
+              line-height: 1.6;
+          }
+          .footer {
+              text-align: center;
+              padding: 10px;
+              background-color: #f1f1f1;
+              font-size: 14px;
+              color: #666666;
+          }
+          .footer a {
+              color: #007bff;
+              text-decoration: none;
+          }
+      </style>
+  </head>
+  <body>
+      <div class="container">
+          <div class="header">
+              <h1>Welcome to HITK Tech Community!</h1>
+          </div>
+          <div class="content">
+              <h2>Hello ${SubscriberName},</h2>
+              <p>Thank you for joining the HITK Tech Community! We are excited to have you on board.</p>
+              <p>HITK Tech Community is a platform built by the students and for the students with the main intent of increasing awareness towards the plethora of opportunities and internships in tech all around the year. This will not only give practical work experience and exposure to students but will also help everyone to know and grab their required opportunities in time!</p>
+              <p>In HITK Tech Community, we will have mentors from almost all domains, and members of the community can just put up their queries. Any member having the answer or insight to get the solution will respond to it. Along with addressing the students' queries, all mentors will be sharing valuable event opportunities like:</p>
+              <ul>
+                  <li>Workshops and webinars on the latest tech trends</li>
+                  <li>Internship and job openings</li>
+                  <li>Hackathons and coding competitions</li>
+                  <li>Tech talks and networking events</li>
+              </ul>
+              <p>Welcome once again to the HITK Tech Community. We're glad to have you with us!</p>
+              <p>Best regards,<br>The HITK Tech Team</p>
+          </div>
+          <div class="footer">
+              <p>&copy; 2024 HITK Tech Community. All rights reserved.</p>
+              <p><a href="[Unsubscribe Link]">Unsubscribe</a> | <a href="[Privacy Policy Link]">Privacy Policy</a></p>
+          </div>
+      </div>
+  </body>
+</html>
+  `;
+  return emailContent;
+}
+
+module.exports.NewBroadCastMailTemplate = (subscriber) => {
+  const emailContent = `
+  <!DOCTYPE html>
+  <html lang="en">
+  <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>New Broadcast from HITK Tech Community</title>
+      <style>
+          body {
+              font-family: Arial, sans-serif;
+              margin: 0;
+              padding: 0;
+              background-color: #f6f6f6;
+          }
+          .container {
+              width: 100%;
+              padding: 20px;
+              background-color: #ffffff;
+              margin: 0 auto;
+              max-width: 600px;
+              box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+          }
+          .header {
+              text-align: center;
+              background-color: #007bff;
+              color: #ffffff;
+              padding: 10px 0;
+          }
+          .header h1 {
+              margin: 0;
+              font-size: 24px;
+          }
+          .content {
+              padding: 20px;
+          }
+          .content h2 {
+              font-size: 20px;
+              color: #333333;
+          }
+          .content p {
+              font-size: 16px;
+              color: #666666;
+              line-height: 1.6;
+          }
+          .tags {
+              margin-top: 10px;
+              padding: 10px 0;
+          }
+          .tag {
+              display: inline-block;
+              background-color: #007bff;
+              color: #ffffff;
+              padding: 5px 10px;
+              margin: 5px 0;
+              border-radius: 3px;
+              font-size: 14px;
+          }
+          .footer {
+              text-align: center;
+              padding: 10px;
+              background-color: #f1f1f1;
+              font-size: 14px;
+              color: #666666;
+          }
+          .footer a {
+              color: #007bff;
+              text-decoration: none;
+          }
+      </style>
+  </head>
+  <body>
+      <div class="container">
+          <div class="header">
+              <h1>New Broadcast from HITK Tech Community</h1>
+          </div>
+          <div class="content">
+              <h2>${subscriber.title}</h2>
+              <p>${subscriber.content}</p>
+              <p><strong>Expires On:</strong> ${subscriber.expiresOn}</p>
+              <p><a href="${subscriber.link}" target="_blank">link</a></p>
+              <div class="tags">
+                  <strong>Tags:</strong>
+                  <p>
+                      ${subscriber.tags}
+                  </p>
+              </div>
+          </div>
+          <div class="footer">
+              <p>&copy; 2024 HITK Tech Community. All rights reserved.</p>
+              <p><a href="[Unsubscribe Link]">Unsubscribe</a> | <a href="[Privacy Policy Link]">Privacy Policy</a></p>
+          </div>
+      </div>
+  </body>
+</html>
+  `;
+  return emailContent;
+}

--- a/backend/utility/sendEmail.js
+++ b/backend/utility/sendEmail.js
@@ -1,4 +1,5 @@
 const sgMail = require('@sendgrid/mail');
+const nodemailer = require("nodemailer");
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 const sendEmail = (to, subject, text) => {
@@ -17,4 +18,26 @@ const sendEmail = (to, subject, text) => {
   });
 };
 
-module.exports = sendEmail;
+const transporter = nodemailer.createTransport({
+  service: "gmail",
+  auth: {
+      user: process.env.EMAIL_ID_FOR_SENDING_MAIL,
+      pass: process.env.EMAIL_PASS_FOR_NODEMAILER
+  }
+});
+
+const SendEmailUsingNodeMailer = (to, subject, text) => {
+  const mailoption = {
+    from : { name: 'HITE-TECH' , email:process.env.EMAIL_ID_FOR_SENDING_MAIL},
+    to : to,
+    subject : subject,
+    html: text
+  }
+  transporter.sendMail(mailoption, function(error, info){
+    if(error){
+      return error;
+    }
+  })
+}
+
+module.exports = {sendEmail, SendEmailUsingNodeMailer};


### PR DESCRIPTION
… any new broadcast is added then also mail sent to the registered users only backend part is completed 

## Issue that this pull request solves

 Closes: #870

## Proposed changes

### when new user is registered in the website using email and password then welcome mail is sent to the user and every time when new podcast is generated then mail is send to the registered user

## Backend part is added

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

enter mail id which is used to sent the mail to registered user in the .env file of backend
enter passkey of that mail id in the EMAIL_ID_FOR_SENDING_MAIL in the .env file of backend 
